### PR TITLE
Manage mode - UI for creating database-backed tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,34 @@ You can now run authenticated API queries like this:
     $ curl http://127.0.0.1:8001/:memory:/show_version.json?_shape=array&_auth_token=this-is-the-secret-token
     [{"sqlite_version()": "3.31.1"}]
 
-## Tokens from your database
+## Managed tokens mode
 
-As an alternative (or in addition) to the hard-coded list of tokens you can store tokens in a database table and configure the plugin to access them using a SQL query.
+`datasette-auth-tokens` provides a managed tokens mode, where tokens are stored in a SQLite database table and the plugin provides an interface for creating and revoking tokens.
+
+To turn this mode on, add `"manage_tokens": true` to your plugin configuration in `metadata.json`:
+
+```json
+{
+    "plugins": {
+        "datasette-auth-tokens": {
+            "manage_tokens": true
+        }
+    }
+}
+```
+This will add a "Create API token" option to the Datasette menu.
+
+Tokens that are created will be kept in a new `_datasette_auth_tokens` table.
+
+Navigating to that table page will provide the option to view and revoke tokens.
+
+When you create a new token a signed token string will be presented to you. You need to store this, as it is not stored directly in the database table and can only be retrieved once.
+
+## Custom tokens from your database
+
+If you decide not to use managed tokens mode, you can instead configure `datasette-auth-tokens` to use tokens that are stored in your own custom database tables.
+
+You can do this by configuring a custom SQL query that will execute to test if an incoming token is valid.
 
 Your query needs to take a `:token_id` parameter and return at least two columns: one called `token_secret` and one called `actor_*` - usually `actor_id`. Further `actor_` prefixed columns can be returned to provide more details for the authenticated actor.
 
@@ -169,7 +194,7 @@ To configure this, use a `"query"` block in your plugin configuration like this:
 ```
 The `"sql"` key here contains the SQL query. The `"database"` key has the name of the attached database file that the query should be executed against - in this case it would execute against `tokens.db`.
 
-### Securing your tokens
+### Securing your custom tokens
 
 Anyone with access to your Datasette instance can use it to read the `token_secret` column in your tokens table. This probably isn't what you want!
 

--- a/datasette_auth_tokens/__init__.py
+++ b/datasette_auth_tokens/__init__.py
@@ -29,16 +29,23 @@ TOKEN_STATUSES = {
 @hookimpl
 def table_actions(datasette, actor, database, table):
     if actor and table == "_datasette_auth_tokens":
-        try:
-            check_permission(datasette, actor)
-        except Forbidden:
-            return
-        return [
-            {
-                "href": datasette.urls.path("/-/api/tokens/create"),
-                "label": "Create API token",
-            }
-        ]
+        return menu_links(datasette, actor)
+
+
+@hookimpl
+def menu_links(datasette, actor):
+    if not actor:
+        return
+    try:
+        check_permission(datasette, actor)
+    except Forbidden:
+        return
+    return [
+        {
+            "href": datasette.urls.path("/-/api/tokens/create"),
+            "label": "Create API token",
+        }
+    ]
 
 
 @hookimpl

--- a/datasette_auth_tokens/__init__.py
+++ b/datasette_auth_tokens/__init__.py
@@ -1,4 +1,4 @@
-from datasette import hookimpl, Forbidden
+from datasette import hookimpl
 import json
 import secrets
 import time
@@ -139,7 +139,7 @@ async def _actor_from_managed(datasette, incoming_token):
             "update _datasette_auth_tokens set token_status='E' where id=:token_id",
             {"token_id": token_id},
         )
-        raise Forbidden("Token has expired")
+        return None
 
     # Update last_used_timestamp if more than 60 seconds old
     if row["last_used_timestamp"] is None or (

--- a/datasette_auth_tokens/templates/create_api_token.html
+++ b/datasette_auth_tokens/templates/create_api_token.html
@@ -1,0 +1,169 @@
+{% extends "base.html" %}
+
+{% block title %}Create an API token{% endblock %}
+
+{% block extra_head %}
+<style type="text/css">
+#restrict-permissions label {
+  display: inline;
+  width: 90%;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+
+<h1>Create an API token</h1>
+
+<p>This token will allow API access with the same abilities as your current user, <strong>{{ request.actor.id }}</strong></p>
+
+{% if token %}
+  <div>
+    <h2>Your API token</h2>
+    <form>
+      <input type="text" class="copyable" style="width: 40%" value="{{ token }}">
+      <span class="copy-link-wrapper"></span>
+    </form>
+    <!--- show token in a <details> -->
+    <details style="margin-top: 1em">
+      <summary>Token details</summary>
+      <pre>{{ token_bits|tojson(4) }}</pre>
+    </details>
+  </div>
+  <h2>Create another token</h2>
+{% endif %}
+
+{% if errors %}
+  {% for error in errors %}
+    <p class="message-error">{{ error }}</p>
+  {% endfor %}
+{% endif %}
+
+<form action="{{ urls.path('-/api/tokens/create') }}" method="post">
+  <div>
+    <div style="margin-bottom: 0.5em">
+      <input type="text" name="description" placeholder="Optional token description" style="width: 40%">
+    </div>
+    <div class="select-wrapper" style="width: unset">
+      <select name="expire_type">
+        <option value="">Token never expires</option>
+        <option value="minutes">Expires after X minutes</option>
+        <option value="hours">Expires after X hours</option>
+        <option value="days">Expires after X days</option>
+      </select>
+    </div>
+    <input type="text" name="expire_duration" style="width: 10%">
+    <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+    <input type="submit" value="Create token">
+
+    <p style="margin-top: 1em" id="token-summary"></p>
+
+    <h2>All databases and tables</h2>
+    <ul>
+      {% for permission in all_permissions %}
+        <li><label><input type="checkbox" name="all:{{ permission }}"> {{ permission }}</label></li>
+      {% endfor %}
+    </ul>
+
+    {% for database in database_with_tables %}
+      <h2>All tables in "{{ database.name }}"</h2>
+      <ul>
+        {% for permission in database_permissions %}
+          <li><label><input type="checkbox" name="database:{{ database.encoded }}:{{ permission }}"> {{ permission }}</label></li>
+        {% endfor %}
+      </ul>
+    {% endfor %}
+    <h2>Specific tables</h2>
+    {% for database in database_with_tables %}
+      {% for table in database.tables %}
+        <h3>{{ database.name }}: {{ table.name }}</h3>
+        <ul>
+          {% for permission in resource_permissions %}
+            <li><label><input type="checkbox" name="resource:{{ database.encoded }}:{{ table.encoded }}:{{ permission }}"> {{ permission }}</label></li>
+          {% endfor %}
+        </ul>
+      {% endfor %}
+    {% endfor %}
+
+</form>
+</div>
+
+<script>
+var expireDuration = document.querySelector('input[name="expire_duration"]');
+expireDuration.style.display = 'none';
+var expireType = document.querySelector('select[name="expire_type"]');
+function showHideExpireDuration() {
+  if (expireType.value) {
+    expireDuration.style.display = 'inline';
+    expireDuration.setAttribute("placeholder", expireType.value.replace("Expires after X ", ""));
+  } else {
+    expireDuration.style.display = 'none';
+  }
+}
+
+function updateTokenSummary() {
+  // Get all selected checkbox values on page
+  var allChecked = document.querySelectorAll('input[type="checkbox"]:checked');
+  var checkedValues = [];
+  for (var i = 0; i < allChecked.length; i++) {
+    checkedValues.push(humanPermission(allChecked[i].name));
+  }
+  var tokenSummary = document.querySelector('#token-summary');
+  if (checkedValues.length == 0) {
+    tokenSummary.innerHTML = 'Token will have all of the permissions of your current user';
+  } else {
+    // Build a <ul> of checkedValues
+    let html = ['<ul style="margin-top: 0.5em">'];
+    checkedValues.forEach(function(value) {
+      html.push('<li style="list-style-type: disc; margin-left: 1em;">' + value + '</li>');
+    });
+    html.push('</ul>');
+    tokenSummary.innerHTML = 'Token will be restricted to: ' + html.join('');
+  }
+}
+updateTokenSummary();
+
+function humanPermission(permission) {
+  // database:messages:view-database becomes "messages database: view-database"
+  // resource:messages:t2:view-table becomes "messages/t2 table: view-table"
+  var parts = permission.split(':');
+  var type = parts[0];
+  var db = parts[1];
+  var action = parts[parts.length - 1];
+  if (type == 'all') {
+    return 'all databases and tables: ' + action;
+  } else if (type == 'database') {
+    return db + ' database: ' + action;
+  } else if (type == 'resource') {
+    var table = parts[2];
+    return db + '/' + table + ' table: ' + action;
+  }
+}
+
+// On any input change on page, update token summary
+document.addEventListener('change', updateTokenSummary);
+
+showHideExpireDuration();
+expireType.addEventListener('change', showHideExpireDuration);
+var copyInput = document.querySelector(".copyable");
+if (copyInput) {
+  var wrapper = document.querySelector(".copy-link-wrapper");
+  var button = document.createElement("button");
+  button.className = "copyable-copy-button";
+  button.setAttribute("type", "button");
+  button.innerHTML = "Copy to clipboard";
+  button.onclick = (ev) => {
+    ev.preventDefault();
+    copyInput.select();
+    document.execCommand("copy");
+    button.innerHTML = "Copied!";
+    setTimeout(() => {
+        button.innerHTML = "Copy to clipboard";
+    }, 1500);
+  };
+  wrapper.appendChild(button);
+  wrapper.insertAdjacentElement("afterbegin", button);
+}
+</script>
+
+{% endblock %}

--- a/datasette_auth_tokens/templates/token_details.html
+++ b/datasette_auth_tokens/templates/token_details.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}API token{% if token.description %}: {{ token.description }}{% endif %}{% endblock %}
+
+{% block extra_head %}
+<style type="text/css">
+dt {
+    font-weight: bold;
+}
+dd {
+    margin-left: 2em;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+
+<h1>API token: {{ token.id }}</h1>
+
+<dl>
+    {% if token.description %}
+        <dt>Description</dt>
+        <dd>{{ token.description }}</dd>
+    {% endif %}
+    <dt>Token status</dt>
+    <dd>{{ token_status }}</dd>
+    <dt>Actor</dt>
+    <dd>{{ token.actor_id }}</dd>
+    <dt>Created</dt>
+    <dd>{{ timestamp(token.created_timestamp) }}</dd>
+    <dt>Last used</dt>
+    <dd>{{ timestamp(token.last_used_timestamp) }}</dd>
+    <dt>Restrictions</dt>
+    <dd><pre>{{ restrictions }}</pre></dd>
+</dl>
+
+{% if token_status == "Live" %}
+<form action="" method="POST">
+    <p>
+        <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+        <input type="submit" name="revoke" value="Revoke token">
+    </p>
+</form>
+{% endif %}
+
+{% endblock %}

--- a/datasette_auth_tokens/views.py
+++ b/datasette_auth_tokens/views.py
@@ -8,7 +8,7 @@ import time
 
 
 async def create_api_token(request, datasette):
-    _check_permission(datasette, request)
+    check_permission(datasette, request.actor)
     if request.method == "GET":
         return Response.html(
             await datasette.render_template(
@@ -105,21 +105,21 @@ async def create_api_token(request, datasette):
         raise Forbidden("Invalid method")
 
 
-def _check_permission(datasette, request):
-    if not request.actor:
+def check_permission(datasette, actor):
+    if not actor:
         raise Forbidden("You must be logged in to create a token")
-    if not request.actor.get("id"):
+    if not actor.get("id"):
         raise Forbidden(
             "You must be logged in as an actor with an ID to create a token"
         )
-    if request.actor.get("token"):
+    if actor.get("token"):
         raise Forbidden(
             "Token authentication cannot be used to create additional tokens"
         )
 
 
 async def _shared(datasette, request):
-    _check_permission(datasette, request)
+    check_permission(datasette, request.actor)
     # Build list of databases and tables the user has permission to view
     database_with_tables = []
     for database in datasette.databases.values():

--- a/datasette_auth_tokens/views.py
+++ b/datasette_auth_tokens/views.py
@@ -1,0 +1,163 @@
+from datasette import Forbidden, Response
+from datasette.utils import (
+    tilde_encode,
+    tilde_decode,
+)
+import json
+import secrets
+import time
+
+
+async def create_api_token(request, datasette):
+    _check_permission(datasette, request)
+    if request.method == "GET":
+        return Response.html(
+            await datasette.render_template(
+                "create_api_token.html",
+                await _shared(datasette, request),
+                request=request,
+            )
+        )
+    elif request.method == "POST":
+        post = await request.post_vars()
+        errors = []
+        expires_after = None
+        if post.get("expire_type"):
+            duration_string = post.get("expire_duration")
+            if (
+                not duration_string
+                or not duration_string.isdigit()
+                or not int(duration_string) > 0
+            ):
+                errors.append("Invalid expire duration")
+            else:
+                unit = post["expire_type"]
+                if unit == "minutes":
+                    expires_after = int(duration_string) * 60
+                elif unit == "hours":
+                    expires_after = int(duration_string) * 60 * 60
+                elif unit == "days":
+                    expires_after = int(duration_string) * 60 * 60 * 24
+                else:
+                    errors.append("Invalid expire duration unit")
+
+        # Are there any restrictions?
+        restrict_all = []
+        restrict_database = {}
+        restrict_resource = {}
+
+        for key in post:
+            if key.startswith("all:") and key.count(":") == 1:
+                restrict_all.append(key.split(":")[1])
+            elif key.startswith("database:") and key.count(":") == 2:
+                bits = key.split(":")
+                database = tilde_decode(bits[1])
+                action = bits[2]
+                restrict_database.setdefault(database, []).append(action)
+            elif key.startswith("resource:") and key.count(":") == 3:
+                bits = key.split(":")
+                database = tilde_decode(bits[1])
+                resource = tilde_decode(bits[2])
+                action = bits[3]
+                restrict_resource.setdefault(database, {}).setdefault(
+                    resource, []
+                ).append(action)
+
+        # Reuse Datasette signed tokens mechanism to create parts of the token
+        throwaway_signed_token = datasette.create_token(
+            request.actor["id"],
+            expires_after=expires_after,
+            restrict_all=restrict_all,
+            restrict_database=restrict_database,
+            restrict_resource=restrict_resource,
+        )
+        token_bits = datasette.unsign(
+            throwaway_signed_token[len("dstok_") :], namespace="token"
+        )
+        permissions = token_bits.get("_r") or None
+
+        db = datasette.get_database()
+        secret = secrets.token_urlsafe(16)
+        cursor = await db.execute_write(
+            """
+            insert into _datasette_auth_tokens
+            (secret, description, permissions, actor_id, created_timestamp, expires_after_seconds)
+            values
+            (:secret, :description, :permissions, :actor_id, :created_timestamp, :expires_after_seconds)
+        """,
+            {
+                "secret": secret,
+                "permissions": json.dumps(permissions),
+                "description": post.get("description") or None,
+                "actor_id": request.actor["id"],
+                "created_timestamp": int(time.time()),
+                "expires_after_seconds": expires_after,
+            },
+        )
+        token = "dsatok_{}_{}".format(cursor.lastrowid, secret)
+
+        context = await _shared(datasette, request)
+        context.update({"errors": errors, "token": token, "token_bits": token_bits})
+        return Response.html(
+            await datasette.render_template(
+                "create_api_token.html", context, request=request
+            )
+        )
+    else:
+        raise Forbidden("Invalid method")
+
+
+def _check_permission(datasette, request):
+    if not request.actor:
+        raise Forbidden("You must be logged in to create a token")
+    if not request.actor.get("id"):
+        raise Forbidden(
+            "You must be logged in as an actor with an ID to create a token"
+        )
+    if request.actor.get("token"):
+        raise Forbidden(
+            "Token authentication cannot be used to create additional tokens"
+        )
+
+
+async def _shared(datasette, request):
+    _check_permission(datasette, request)
+    # Build list of databases and tables the user has permission to view
+    database_with_tables = []
+    for database in datasette.databases.values():
+        if database.name in ("_internal", "_memory"):
+            continue
+        if not await datasette.permission_allowed(
+            request.actor, "view-database", database.name
+        ):
+            continue
+        hidden_tables = await database.hidden_table_names()
+        tables = []
+        for table in await database.table_names():
+            if table in hidden_tables:
+                continue
+            if not await datasette.permission_allowed(
+                request.actor,
+                "view-table",
+                resource=(database.name, table),
+            ):
+                continue
+            tables.append({"name": table, "encoded": tilde_encode(table)})
+        database_with_tables.append(
+            {
+                "name": database.name,
+                "encoded": tilde_encode(database.name),
+                "tables": tables,
+            }
+        )
+    return {
+        "actor": request.actor,
+        "all_permissions": datasette.permissions.keys(),
+        "database_permissions": [
+            key for key, value in datasette.permissions.items() if value.takes_database
+        ],
+        "resource_permissions": [
+            key for key, value in datasette.permissions.items() if value.takes_resource
+        ],
+        "database_with_tables": database_with_tables,
+    }

--- a/datasette_auth_tokens/views.py
+++ b/datasette_auth_tokens/views.py
@@ -4,7 +4,6 @@ from datasette.utils import (
     tilde_decode,
 )
 import json
-import secrets
 import time
 
 
@@ -80,12 +79,12 @@ async def create_api_token(request, datasette):
         cursor = await db.execute_write(
             """
             insert into _datasette_auth_tokens
-            (secret_id, description, permissions, actor_id, created_timestamp, expires_after_seconds)
+            (secret_version, description, permissions, actor_id, created_timestamp, expires_after_seconds)
             values
-            (:secret_id, :description, :permissions, :actor_id, :created_timestamp, :expires_after_seconds)
+            (:secret_version, :description, :permissions, :actor_id, :created_timestamp, :expires_after_seconds)
         """,
             {
-                "secret_id": 0,
+                "secret_version": 0,
                 "permissions": json.dumps(permissions),
                 "description": post.get("description") or None,
                 "actor_id": request.actor["id"],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,10 @@ setup(
     entry_points={"datasette": ["auth_tokens = datasette_auth_tokens"]},
     install_requires=[
         "datasette>=0.44",
+        "sqlite-utils",
     ],
     extras_require={"test": ["pytest", "pytest-asyncio", "httpx", "sqlite-utils"]},
-    tests_require=["datasette-auth-tokens[test]"],
+    package_data={
+        "datasette_auth_tokens": ["templates/*.html"]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=["datasette_auth_tokens"],
     entry_points={"datasette": ["auth_tokens = datasette_auth_tokens"]},
     install_requires=[
-        "datasette>=0.44",
+        "datasette>=1.0a2",
         "sqlite-utils",
     ],
     extras_require={"test": ["pytest", "pytest-asyncio", "httpx", "sqlite-utils"]},

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,5 @@ setup(
         "sqlite-utils",
     ],
     extras_require={"test": ["pytest", "pytest-asyncio", "httpx", "sqlite-utils"]},
-    package_data={
-        "datasette_auth_tokens": ["templates/*.html"]
-    },
+    package_data={"datasette_auth_tokens": ["templates/*.html"]},
 )

--- a/tests/test_managed_tokens.py
+++ b/tests/test_managed_tokens.py
@@ -2,6 +2,7 @@ from datasette.app import Datasette
 import pytest
 import pytest_asyncio
 import sqlite_utils
+import time
 
 
 @pytest_asyncio.fixture
@@ -20,6 +21,53 @@ async def ds_managed(tmp_path_factory):
             },
         },
     )
+
+
+@pytest.mark.parametrize("status", ("live", "revoked", "expired"))
+@pytest.mark.asyncio
+async def test_live_revoked_expired_tokens(ds_managed, status):
+    token_id, token = await _create_token(ds_managed)
+    expected_actor = {"id": "root", "token": "dsatok"}
+    if status in ("revoked", "expired"):
+        expected_actor = None
+    if status == "revoked":
+        await ds_managed.get_database().execute_write(
+            "update _datasette_auth_tokens set token_status = 'R' where id=:id",
+            {"id": token_id},
+        )
+    elif status == "expired":
+        # Expire it by setting the created_timestamp and expires_after_seconds
+        await ds_managed.get_database().execute_write(
+            "update _datasette_auth_tokens set created_timestamp = :created, expires_after_seconds = 60 where id=:id",
+            {"id": token_id, "created": time.time() - 120},
+        )
+    actor_response = await ds_managed.client.get(
+        "/-/actor.json", headers={"Authorization": "Bearer {}".format(token)}
+    )
+    assert actor_response.status_code == 200
+    assert actor_response.json() == {"actor": expected_actor}
+
+
+async def _create_token(ds_managed):
+    root_cookie = ds_managed.sign({"a": {"id": "root"}}, "actor")
+    create_page = await ds_managed.client.get(
+        "/-/api/tokens/create", cookies={"ds_actor": root_cookie}
+    )
+    ds_csrftoken = create_page.cookies["ds_csrftoken"]
+    post_fields = {}
+    post_fields["csrftoken"] = ds_csrftoken
+    response = await ds_managed.client.post(
+        "/-/api/tokens/create",
+        data=post_fields,
+        cookies={"ds_actor": root_cookie, "ds_csrftoken": ds_csrftoken},
+    )
+    assert response.status_code == 200
+    api_token = response.text.split('class="copyable" style="width: 40%" value="')[
+        1
+    ].split('"')[0]
+    # Decode token to find token ID
+    token_id = ds_managed.unsign(api_token.split("dsatok_")[1], namespace="dsatok")
+    return token_id, api_token
 
 
 @pytest.mark.parametrize(
@@ -41,7 +89,6 @@ async def test_create_token(ds_managed, post_fields, expected_actor):
         "/-/api/tokens/create", cookies={"ds_actor": cookie}
     )
     assert create_page.status_code == 200
-    print(create_page.text)
     # Extract ds_csrftoken
     ds_csrftoken = create_page.cookies["ds_csrftoken"]
     # Use that to create the token

--- a/tests/test_managed_tokens.py
+++ b/tests/test_managed_tokens.py
@@ -1,0 +1,64 @@
+from datasette.app import Datasette
+import pytest
+import pytest_asyncio
+import sqlite_utils
+
+
+@pytest_asyncio.fixture
+async def ds_managed(tmp_path_factory):
+    db_directory = tmp_path_factory.mktemp("dbs")
+    db_path = db_directory / "demo.db"
+    sqlite_utils.Database(db_path)["foo"].insert({"bar": 1})
+    return Datasette(
+        [db_path],
+        metadata={
+            "plugins": {
+                "datasette-auth-tokens": {
+                    "manage_tokens": True,
+                    "param": "_auth_token",
+                }
+            },
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "post_fields,expected_actor",
+    [
+        ({}, {"id": "root", "token": "dsatok"}),
+        (
+            {"resource:demo:foo:view-table": "1"},
+            {"id": "root", "token": "dsatok", "_r": {"r": {"demo": {"foo": ["vt"]}}}},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_token(ds_managed, post_fields, expected_actor):
+    # TODO: switch to ds_managed.client.actor_cookie after next Datasette release
+    cookie = ds_managed.sign({"a": {"id": "root"}}, "actor")
+    # Load initial create token page
+    create_page = await ds_managed.client.get(
+        "/-/api/tokens/create", cookies={"ds_actor": cookie}
+    )
+    assert create_page.status_code == 200
+    print(create_page.text)
+    # Extract ds_csrftoken
+    ds_csrftoken = create_page.cookies["ds_csrftoken"]
+    # Use that to create the token
+    post_fields["csrftoken"] = ds_csrftoken
+    response = await ds_managed.client.post(
+        "/-/api/tokens/create",
+        data=post_fields,
+        cookies={"ds_actor": cookie, "ds_csrftoken": ds_csrftoken},
+    )
+    assert response.status_code == 200
+    api_token = response.text.split('class="copyable" style="width: 40%" value="')[
+        1
+    ].split('"')[0]
+    assert api_token
+    # Now try using it to request /-/actor.json
+    response = await ds_managed.client.get(
+        "/-/actor.json", headers={"Authorization": "Bearer {}".format(api_token)}
+    )
+    assert response.status_code == 200
+    assert response.json()["actor"] == expected_actor


### PR DESCRIPTION
Refs:
- #7

TODO:
- [x] DB schema
- [x] Create tokens page, saving tokens to DB
- [x] Update authentication code to read tokens from that table
- [x] Update `last_used_timestamp` every X seconds (X=60 at first)
- [x] Interface to list currently issued tokens
- Hide the `_datasette_auth_tokens` table by default - this will happen with https://github.com/simonw/datasette/issues/2104
- [x] Ability to revoke tokens
- [x] Tests
- [x] Documentation

Not for this PR but to come later: ability to edit tokens, more advanced audit trail functionality.