### PR TITLE
Use TokenRestrictions API for token creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ venv
 .eggs
 .pytest_cache
 *.egg-info
+build/
+dist/

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=["datasette_auth_tokens"],
     entry_points={"datasette": ["auth_tokens = datasette_auth_tokens"]},
     install_requires=[
-        "datasette>=1.0a21",
+        "datasette>=1.0a25",
         "sqlite-utils",
         "sqlite-migrate",
     ],


### PR DESCRIPTION
Refs:
- https://github.com/simonw/datasette/pull/2650#issuecomment-3962909365

This PR updates the token creation logic to use Datasette's `TokenRestrictions` API instead of manually managing restriction dictionaries.

## Summary
Refactored the `create_api_token` view to leverage the `TokenRestrictions` class from `datasette.tokens`, simplifying the code and improving maintainability.

## Key changes
- Replaced manual restriction dictionary management (`restrict_all`, `restrict_database`, `restrict_resource`) with `TokenRestrictions()` instance
- Updated restriction building to use `TokenRestrictions` methods: `allow_all()`, `allow_database()`, and `allow_resource()`
- Changed `datasette.create_token()` call to `await datasette.create_token()` (now async)
- Updated token creation call to pass `restrictions` parameter instead of individual restriction parameters
- Added `.gitignore` entries for `build/` and `dist/` directories

## Implementation details
The `TokenRestrictions` class provides a cleaner API for building token restrictions, eliminating the need for nested dictionary manipulation. The restriction building loop now directly calls methods on the `TokenRestrictions` instance, making the code more readable and less error-prone.

https://claude.ai/code/session_01RbZveeSogxSnjJ5yr6AFtq