### PR TITLE
Register as a token handler using new register_token_handler() plugin hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Enable it using the `param` config value:
           },
           "actor": {
             "bot_id": "my-bot"
-          },
+          }
         }
       ],
       "param": "_auth_token"

--- a/README.md
+++ b/README.md
@@ -13,117 +13,15 @@ Install this plugin in the same environment as Datasette.
 ```bash
 datasette install datasette-auth-tokens
 ```
-## Hard-coded tokens
+
+## Configuration
 
 Read about Datasette's [authentication and permissions system](https://datasette.readthedocs.io/en/latest/authentication.html).
 
-This plugin lets you configure secret API tokens which can be used to make authenticated requests to Datasette.
+This plugin can run in two modes. The first mode provides database-backed token management - users can create new tokens for their account and control which resources those tokens can access.
 
-First, create a random API token. A useful recipe for doing that is the following:
-```bash
-python -c 'import secrets; print(secrets.token_hex(32))'
-```
-```
-5f9a486dd807de632200b17508c75002bb66ca6fde1993db1de6cbd446362589
-```
-Decide on the actor that this token should represent, for example:
+The second, simpler mode allows you to define hard-coded tokens in Datasette's static configuration.
 
-```json
-{
-    "bot_id": "my-bot"
-}
-```
-
-You can then use `"allow"` blocks to provide that token with permission to access specific actions. To enable access to a configured writable SQL query you could use this in your `config.json` (for Datasette 1.0) or `metadata.json`: 
-
-```json
-{
-    "plugins": {
-        "datasette-auth-tokens": {
-            "tokens": [
-                {
-                    "token": {
-                        "$env": "BOT_TOKEN"
-                    },
-                    "actor": {
-                        "bot_id": "my-bot"
-                    }
-                }
-            ]
-        }
-    },
-    "databases": {
-        ":memory:": {
-            "queries": {
-                "show_version": {
-                    "sql": "select sqlite_version()",
-                    "allow": {
-                        "bot_id": "my-bot"
-                    }
-                }
-            }
-        }
-    }
-}
-```
-This uses Datasette's [secret configuration values mechanism](https://datasette.readthedocs.io/en/stable/plugins.html#secret-configuration-values) to allow the secret token to be passed as an environment variable.
-
-Run Datasette like this:
-```bash
-BOT_TOKEN="this-is-the-secret-token" \
-    datasette -c config.json
-```
-You can now run authenticated API queries like this:
-```bash
-curl -H 'Authorization: Bearer this-is-the-secret-token' \
-  'http://127.0.0.1:8001/:memory:/show_version.json?_shape=array'
-```
-```json
-[{"sqlite_version()": "3.31.1"}]
-```
-Additionally you can allow passing the token as a query string parameter, although that's disabled by default given the security implications of URLs with secret tokens included. This may be useful to easily allow embedding data between different services.
-
-Enable it using the `param` config value:
-
-```json
-{
-    "plugins": {
-        "datasette-auth-tokens": {
-            "tokens": [
-                {
-                    "token": {
-                        "$env": "BOT_TOKEN"
-                    },
-                    "actor": {
-                        "bot_id": "my-bot"
-                    },
-                }
-            ],
-            "param": "_auth_token"
-        }
-    },
-    "databases": {
-        ":memory:": {
-            "queries": {
-                "show_version": {
-                    "sql": "select sqlite_version()",
-                    "allow": {
-                        "bot_id": "my-bot"
-                    }
-                }
-            }
-        }
-    }
-}
-```
-
-You can now run authenticated API queries like this:
-```bash
-curl http://127.0.0.1:8001/:memory:/show_version.json?_shape=array&_auth_token=this-is-the-secret-token
-```
-```json
-[{"sqlite_version()": "3.31.1"}]
-```
 ## Managed tokens mode
 
 `datasette-auth-tokens` provides a managed tokens mode, where tokens are stored in a SQLite database table and the plugin provides an interface for creating and revoking tokens.
@@ -132,11 +30,11 @@ To turn this mode on, add `"manage_tokens": true` to your plugin configuration:
 
 ```json
 {
-    "plugins": {
-        "datasette-auth-tokens": {
-            "manage_tokens": true
-        }
+  "plugins": {
+    "datasette-auth-tokens": {
+      "manage_tokens": true
     }
+  }
 }
 ```
 This will add a "Create API token" option to the Datasette menu.
@@ -147,11 +45,11 @@ Users need the `auth-tokens-create` permission to create tokens. One way to gran
 
 ```json
 {
-    "permissions": {
-        "auth-tokens-create": {
-            "id": "*"
-        }
+  "permissions": {
+    "auth-tokens-create": {
+      "id": "*"
     }
+  }
 }
 ```
 
@@ -159,16 +57,18 @@ Use the "Create API token" option in the Datasette menu or navigate to `/-/api/t
 
 When you create a new token a signed token string will be presented to you. You need to store this, as it is not stored directly in the database table and can only be retrieved once.
 
+Managed tokens use the `dsatok_` prefix - for example `dsatok_abc123...`. This prefix identifies them as tokens issued by this plugin.
+
 If you have multiple databases attached to Datasette you will need to specify which database should be used for the `_datasette_auth_tokens` table. You can do this with the `manage_tokens_database` setting:
 
 ```json
 {
-    "plugins": {
-        "datasette-auth-tokens": {
-            "manage_tokens": true,
-            "manage_tokens_database": "tokens"
-        }
+  "plugins": {
+    "datasette-auth-tokens": {
+      "manage_tokens": true,
+      "manage_tokens_database": "tokens"
     }
+  }
 }
 ```
 Now start Datasette like this:
@@ -185,6 +85,24 @@ datasette \
   -s permissions.auth-tokens-create.id '*' # to enable token creation
 ```
 
+### Token restrictions
+
+When creating a token through the `/-/api/tokens/create` page, you can optionally restrict the token to specific permissions. If no restrictions are selected the token will have all of the permissions of the creating user.
+
+Restrictions can be applied at three levels:
+
+- **All databases and tables** - grant specific permissions across the entire Datasette instance
+- **All tables in a specific database** - grant permissions scoped to a single database
+- **Specific tables in specific databases** - grant permissions scoped to individual tables
+
+Only permissions that the creating user already has will be available for selection.
+
+### Token expiration
+
+Tokens can optionally be configured to expire. When creating a token you can set it to expire after a specified number of minutes, hours, or days.
+
+Expired tokens are automatically marked with an "Expired" status and will no longer authenticate requests.
+
 ### Viewing tokens
 
 By default, users can only view tokens that they themselves have created on the `/-/api/tokens` page.
@@ -196,6 +114,16 @@ Grant the `auth-tokens-view-all` permission to allow a user to view all tokens, 
 A token can be revoked by the user that created it by clicking the "Revoke this token" button at the bottom of the token page that is linked to from `/-/api/tokens`.
 
 A user with the `auth-tokens-revoke-all` permission can revoke any token.
+
+### Token handler integration
+
+With managed tokens mode enabled, this plugin registers itself as a [token handler](https://docs.datasette.io/en/latest/changelog.html#a25-2026-02-25) using Datasette's `register_token_handler()` plugin hook.
+
+This means that installing this plugin with `manage_tokens` enabled will cause it to become the default token issuing mechanism for the entire Datasette instance, including for other plugins such as [datasette-oauth](https://github.com/datasette/datasette-oauth) that call Datasette's `create_token()` API.
+
+Tokens created through this mechanism - whether via the `/-/api/tokens/create` UI or programmatically by other plugins - are all stored in the `_datasette_auth_tokens` table and use the `dsatok_` prefix.
+
+The handler is registered with `tryfirst=True`, ensuring it takes precedence when multiple token handler plugins are installed.
 
 ## Custom tokens from your database
 
@@ -233,19 +161,19 @@ To configure this, use a `"query"` block in your plugin configuration like this:
 
 ```json
 {
-    "plugins": {
-        "datasette-auth-tokens": {
-            "query": {
-                "sql": "select actor_id, actor_name, token_secret from tokens where token_id = :token_id",
-                "database": "tokens"
-            }
-        }
-    },
-    "databases": {
-        "tokens": {
-            "allow": false
-        }
+  "plugins": {
+    "datasette-auth-tokens": {
+      "query": {
+        "sql": "select actor_id, actor_name, token_secret from tokens where token_id = :token_id",
+        "database": "tokens"
+      }
     }
+  },
+  "databases": {
+    "tokens": {
+      "allow": false
+    }
+  }
 }
 ```
 The `"sql"` key here contains the SQL query. The `"database"` key has the name of the attached database file that the query should be executed against - in this case it would execute against `tokens.db`.
@@ -257,3 +185,123 @@ If you implement the custom pattern above which reads `token_secret` from your o
 To avoid this, you should lock down access to that table. The configuration example above shows how to do this using an `"allow": false` block to deny all access to that `tokens` database.
 
 Consult Datasette's [Permissions documentation](https://datasette.readthedocs.io/en/stable/authentication.html#permissions) for more information about how to lock down this kind of access.
+
+
+## Hard-coded tokens
+
+To configure a hard-coded token, first create a random API token to use. A recipe for doing that is the following:
+```bash
+python -c 'import secrets; print(secrets.token_hex(32))'
+```
+```
+5f9a...
+```
+Decide on the actor that this token should represent, for example:
+
+```json
+{
+    "bot_id": "my-bot"
+}
+```
+
+You can then use `"allow"` blocks to provide that token with permission to access specific actions. To enable access to a configured writable SQL query you could use this in your `config.json` (for Datasette 1.0) or `metadata.json`:
+
+```json
+{
+  "plugins": {
+    "datasette-auth-tokens": {
+      "tokens": [
+        {
+          "token": {
+            "$env": "BOT_TOKEN"
+          },
+          "actor": {
+            "bot_id": "my-bot"
+          }
+        }
+      ]
+    }
+  },
+  "databases": {
+    ":memory:": {
+      "queries": {
+        "show_version": {
+          "sql": "select sqlite_version()",
+          "allow": {
+            "bot_id": "my-bot"
+          }
+        }
+      }
+    }
+  }
+}
+```
+This uses Datasette's [secret configuration values mechanism](https://datasette.readthedocs.io/en/stable/plugins.html#secret-configuration-values) to allow the secret token to be passed as an environment variable.
+
+Run Datasette like this:
+```bash
+BOT_TOKEN="this-is-the-secret-token" \
+    datasette -c config.json
+```
+You can now run authenticated API queries like this:
+```bash
+curl -H 'Authorization: Bearer this-is-the-secret-token' \
+  'http://127.0.0.1:8001/:memory:/show_version.json?_shape=array'
+```
+```json
+[{"sqlite_version()": "3.31.1"}]
+```
+
+## Query string tokens
+
+You can allow passing the token as a query string parameter, although that's disabled by default given the security implications of URLs with secret tokens included. This may be useful to easily allow embedding data between different services.
+
+Enable it using the `param` config value:
+
+```json
+{
+  "plugins": {
+    "datasette-auth-tokens": {
+      "tokens": [
+        {
+          "token": {
+            "$env": "BOT_TOKEN"
+          },
+          "actor": {
+            "bot_id": "my-bot"
+          },
+        }
+      ],
+      "param": "_auth_token"
+    }
+  },
+  "databases": {
+    ":memory:": {
+      "queries": {
+        "show_version": {
+          "sql": "select sqlite_version()",
+          "allow": {
+            "bot_id": "my-bot"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+You can now run authenticated API queries like this:
+```bash
+curl http://127.0.0.1:8001/:memory:/show_version.json?_shape=array&_auth_token=this-is-the-secret-token
+```
+```json
+[{"sqlite_version()": "3.31.1"}]
+```
+
+## Development
+
+To run the tests, clone this repository and run:
+
+```bash
+uv run pytest
+```

--- a/datasette_auth_tokens/__init__.py
+++ b/datasette_auth_tokens/__init__.py
@@ -62,7 +62,7 @@ class ManagedTokenHandler(TokenHandler):
         return await _actor_from_managed(datasette, token)
 
 
-@hookimpl
+@hookimpl(tryfirst=True)
 def register_token_handler(datasette):
     config = Config(datasette)
     if not config.enabled:

--- a/datasette_auth_tokens/__init__.py
+++ b/datasette_auth_tokens/__init__.py
@@ -1,5 +1,6 @@
 from datasette import hookimpl, Forbidden
 from datasette.permissions import Action
+from datasette.tokens import TokenHandler
 import itsdangerous
 import json
 import secrets
@@ -13,6 +14,7 @@ from .views import (
     token_details,
     Config,
 )
+from .utils import abbreviate_restrictions
 from .migrations import migration
 
 TOKEN_STATUSES = {
@@ -20,6 +22,52 @@ TOKEN_STATUSES = {
     "R": "Revoked",
     "E": "Expired",
 }
+
+
+class ManagedTokenHandler(TokenHandler):
+    """Token handler for database-backed managed tokens (dsatok_ prefix)."""
+
+    name = "dsatok"
+
+    async def create_token(
+        self, datasette, actor_id, *, expires_after=None, restrictions=None
+    ):
+        config = Config(datasette)
+        db = config.db
+
+        permissions = abbreviate_restrictions(datasette, restrictions)
+
+        cursor = await db.execute_write(
+            """
+            insert into _datasette_auth_tokens
+            (secret_version, description, permissions, actor_id, created_timestamp, expires_after_seconds)
+            values
+            (:secret_version, :description, :permissions, :actor_id, :created_timestamp, :expires_after_seconds)
+        """,
+            {
+                "secret_version": 0,
+                "permissions": json.dumps(permissions),
+                "description": None,
+                "actor_id": actor_id,
+                "created_timestamp": int(time.time()),
+                "expires_after_seconds": expires_after,
+            },
+        )
+        return "dsatok_{}".format(datasette.sign(cursor.lastrowid, "dsatok"))
+
+    async def verify_token(self, datasette, token):
+        config = Config(datasette)
+        if not config.enabled:
+            return None
+        return await _actor_from_managed(datasette, token)
+
+
+@hookimpl
+def register_token_handler(datasette):
+    config = Config(datasette)
+    if not config.enabled:
+        return None
+    return ManagedTokenHandler()
 
 
 @hookimpl
@@ -120,7 +168,13 @@ def actor_from_request(datasette, request):
             return None
 
         if config.enabled:
-            return await _actor_from_managed(datasette, incoming_token)
+            # For Bearer tokens, return None so Datasette's built-in
+            # actor_from_request handles it via verify_token() and our
+            # ManagedTokenHandler.
+            if authorization:
+                return None
+            # For query param tokens, delegate to verify_token() directly
+            return await datasette.verify_token(incoming_token)
 
         # First try hard-coded tokens in the list
         for token in allowed_tokens:

--- a/datasette_auth_tokens/templates/create_api_token.html
+++ b/datasette_auth_tokens/templates/create_api_token.html
@@ -73,23 +73,27 @@ form div label {
     </ul>
 
     {% for database in database_with_tables %}
+      {% if database.permissions %}
       <h2>All tables in "{{ database.name }}"</h2>
       <ul>
-        {% for permission in database_permissions %}
+        {% for permission in database.permissions %}
           <li><label><input type="checkbox" name="database:{{ database.encoded }}:{{ permission.name }}"> {{ permission.name }}</label> - {{ permission.description }}</li>
         {% endfor %}
       </ul>
+      {% endif %}
     {% endfor %}
     {% if databases_with_at_least_one_table %}
     <h2>Specific tables in specific databases</h2>
     {% for database in databases_with_at_least_one_table %}
       {% for table in database.tables %}
+        {% if table.permissions %}
         <h3>{{ database.name }}: {{ table.name }}</h3>
         <ul>
-          {% for permission in resource_permissions %}
+          {% for permission in table.permissions %}
             <li><label><input type="checkbox" name="resource:{{ database.encoded }}:{{ table.encoded }}:{{ permission.name }}"> {{ permission.name }}</label> - {{ permission.description }}</li>
           {% endfor %}
         </ul>
+        {% endif %}
       {% endfor %}
     {% endfor %}
     {% endif %}

--- a/datasette_auth_tokens/templates/tokens_index.html
+++ b/datasette_auth_tokens/templates/tokens_index.html
@@ -16,6 +16,28 @@ tr.token-E {
   /* Expired */
   background-color: rgb(253, 255, 221);
 }
+.tokens-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+.tokens-table th, .tokens-table td {
+  padding: 0.4em 0.8em;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid #e0e0e0;
+}
+.tokens-table th {
+  border-bottom: 2px solid #ccc;
+}
+.permissions-list {
+  margin: 0;
+  padding: 0 0 0 1.2em;
+  font-size: 0.9em;
+}
+.permissions-group {
+  font-weight: bold;
+  font-size: 0.9em;
+}
 </style>
 {% endblock %}
 
@@ -30,7 +52,7 @@ tr.token-E {
 {% endif %}
 
 {% if tokens %}
-<table>
+<table class="tokens-table">
 <tr>
   <th>Token</th>
   <th>Actor</th>
@@ -43,12 +65,12 @@ tr.token-E {
 {% for token in tokens %}
 <tr class="token-{{ token.token_status }}">
   <td><a href="tokens/{{ token.id }}">{{ token.id }}&nbsp;-&nbsp;{{ token.status }}</a>{% if token.description %}<br><span class="detail">{{ token.description }}</span>{% endif %}</td>
-  <td>{% if token.actor_display %}{{ token.actor_display }} ({{ token.actor_id }}){% else %}{{ token.actor_id }}{% endif %}</td>
+  <td>{% if token.actor_display %}{{ token.actor_display }}<br><span class="detail">{{ token.actor_id }}</span>{% else %}{{ token.actor_id }}{% endif %}</td>
   <td>{{ format_permissions(token.permissions) }}</td>
-  <td>{{ timestamp(token.created_timestamp) }}<br><span class="detail">{{ ago_difference(token.created_timestamp) }}</span></td>
-  <td>{{ timestamp(token.last_used_timestamp) }}<br><span class="detail">{{ ago_difference(token.last_used_timestamp) }}</span></td>
-  <td>{% if token.expires_after_seconds %}{{ timestamp(token.created_timestamp + token.expires_after_seconds) }}<br><span class="detail">{{ ago_difference(token.created_timestamp + token.expires_after_seconds) }}{% endif %}</td>
-  <td>{{ timestamp(token.ended_timestamp) }}<br><span class="detail">{{ ago_difference(token.ended_timestamp) }}</span></td>
+  <td>{{ timestamp(token.created_timestamp) }}{% if token.created_timestamp %}<br><span class="detail">{{ ago_difference(token.created_timestamp) }}</span>{% endif %}</td>
+  <td>{% if token.last_used_timestamp %}{{ timestamp(token.last_used_timestamp) }}<br><span class="detail">{{ ago_difference(token.last_used_timestamp) }}</span>{% endif %}</td>
+  <td>{% if token.expires_after_seconds %}{{ timestamp(token.created_timestamp + token.expires_after_seconds) }}<br><span class="detail">{{ ago_difference(token.created_timestamp + token.expires_after_seconds) }}</span>{% endif %}</td>
+  <td>{% if token.ended_timestamp %}{{ timestamp(token.ended_timestamp) }}<br><span class="detail">{{ ago_difference(token.ended_timestamp) }}</span>{% endif %}</td>
 </tr>
 {% endfor %}
 </table>

--- a/datasette_auth_tokens/utils.py
+++ b/datasette_auth_tokens/utils.py
@@ -76,3 +76,34 @@ def format_permissions(datasette, permissions_dict):
                     output.append(f"- {abbreviations.get(code, code)}")
 
     return "\n".join(output)
+
+
+def abbreviate_restrictions(datasette, restrictions):
+    """Convert a TokenRestrictions object to the abbreviated dict format for storage."""
+    if restrictions is None:
+        return None
+    if not (restrictions.all or restrictions.database or restrictions.resource):
+        return None
+
+    def abbreviate_action(action):
+        action_obj = datasette.actions.get(action)
+        if not action_obj:
+            return action
+        return action_obj.abbr or action
+
+    result = {}
+    if restrictions.all:
+        result["a"] = [abbreviate_action(a) for a in restrictions.all]
+    if restrictions.database:
+        result["d"] = {
+            db: [abbreviate_action(a) for a in actions]
+            for db, actions in restrictions.database.items()
+        }
+    if restrictions.resource:
+        result["r"] = {}
+        for db, resources in restrictions.resource.items():
+            result["r"][db] = {
+                resource: [abbreviate_action(a) for a in actions]
+                for resource, actions in resources.items()
+            }
+    return result

--- a/datasette_auth_tokens/utils.py
+++ b/datasette_auth_tokens/utils.py
@@ -44,13 +44,16 @@ def ago_difference(time1: int, time2: Optional[int] = None):
         return "{} ago".format(combined)
 
 
-def format_permissions(datasette, permissions_dict):
+def format_permissions(datasette, permissions_dict, html=False):
     if not permissions_dict:
         return "All permissions"
     abbreviations = {}
     for action in datasette.actions.values():
         if action.abbr:
             abbreviations[action.abbr] = action.name
+
+    if html:
+        return _format_permissions_html(permissions_dict, abbreviations)
 
     output = []
 
@@ -76,6 +79,33 @@ def format_permissions(datasette, permissions_dict):
                     output.append(f"- {abbreviations.get(code, code)}")
 
     return "\n".join(output)
+
+
+def _format_permissions_html(permissions_dict, abbreviations):
+    from markupsafe import Markup
+
+    parts = []
+
+    def _render_group(label, codes):
+        items = "".join(f"<li>{abbreviations.get(c, c)}</li>" for c in codes)
+        parts.append(
+            f'<span class="permissions-group">{label}</span>'
+            f'<ul class="permissions-list">{items}</ul>'
+        )
+
+    if "a" in permissions_dict:
+        _render_group("All databases", permissions_dict["a"])
+
+    if "d" in permissions_dict:
+        for db, codes in permissions_dict["d"].items():
+            _render_group(f"Database: {db}", codes)
+
+    if "r" in permissions_dict:
+        for db, tables in permissions_dict["r"].items():
+            for table, codes in tables.items():
+                _render_group(f"Table: {db}/{table}", codes)
+
+    return Markup("".join(parts))
 
 
 def abbreviate_restrictions(datasette, restrictions):

--- a/datasette_auth_tokens/views.py
+++ b/datasette_auth_tokens/views.py
@@ -246,7 +246,7 @@ async def tokens_index(datasette, request):
         token["actor_display"] = display_actor(actor) if actor else None
 
     def _format_permissions(json_string):
-        return format_permissions(datasette, json.loads(json_string))
+        return format_permissions(datasette, json.loads(json_string), html=True)
 
     return Response.html(
         await datasette.render_template(
@@ -350,7 +350,7 @@ async def token_details(request, datasette):
 
 def _timestamp(ts):
     if ts:
-        return datetime.datetime.fromtimestamp(ts).isoformat()
+        return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
     else:
         return ""
 

--- a/tests/test_managed_tokens.py
+++ b/tests/test_managed_tokens.py
@@ -226,7 +226,7 @@ async def test_create_token(
     assert response.status_code == 200
     assert f'<a href="tokens/{token_id}">1&nbsp;-&nbsp;Active</a>' in response.text
     if custom_actor_display:
-        assert "<td>Root (root)</td>" in response.text
+        assert "Root<br><span class=\"detail\">root</span>" in response.text
     else:
         assert "<td>root</td>" in response.text
     # And should have its own page

--- a/tests/test_managed_tokens.py
+++ b/tests/test_managed_tokens.py
@@ -460,20 +460,24 @@ async def test_no_table_heading_if_no_tables(tmpdir, has_a_table):
                 "view-database": {"id": "limited"},
             },
             "limited",
-            ["name=\"all:view-table\"", "name=\"all:view-database\""],
-            ["name=\"all:insert-row\"", "name=\"all:alter-table\""],
+            ['name="all:view-table"', 'name="all:view-database"'],
+            ['name="all:insert-row"', 'name="all:alter-table"'],
         ),
         # Default permissions: authenticated user gets view + execute-sql but not write actions
         (
             {},
             "root",
             [
-                "name=\"all:view-table\"",
-                "name=\"all:execute-sql\"",
-                "name=\"database:demo:execute-sql\"",
-                "name=\"resource:demo:foo:view-table\"",
+                'name="all:view-table"',
+                'name="all:execute-sql"',
+                'name="database:demo:execute-sql"',
+                'name="resource:demo:foo:view-table"',
             ],
-            ["name=\"all:insert-row\"", "name=\"all:delete-row\"", "name=\"all:create-table\""],
+            [
+                'name="all:insert-row"',
+                'name="all:delete-row"',
+                'name="all:create-table"',
+            ],
         ),
         # Database-level: user can execute-sql on demo but not create-table
         (
@@ -483,8 +487,8 @@ async def test_no_table_heading_if_no_tables(tmpdir, has_a_table):
                 "execute-sql": {"id": "dbuser"},
             },
             "dbuser",
-            ["name=\"database:demo:execute-sql\""],
-            ["name=\"database:demo:create-table\""],
+            ['name="database:demo:execute-sql"'],
+            ['name="database:demo:create-table"'],
         ),
         # Resource-level: user can view-table but not insert-row on demo/foo
         (
@@ -493,8 +497,8 @@ async def test_no_table_heading_if_no_tables(tmpdir, has_a_table):
                 "view-table": {"id": "viewer"},
             },
             "viewer",
-            ["name=\"resource:demo:foo:view-table\""],
-            ["name=\"resource:demo:foo:insert-row\""],
+            ['name="resource:demo:foo:view-table"'],
+            ['name="resource:demo:foo:insert-row"'],
         ),
         # User with insert-row granted sees it at all levels
         (
@@ -505,10 +509,10 @@ async def test_no_table_heading_if_no_tables(tmpdir, has_a_table):
             },
             "writer",
             [
-                "name=\"all:insert-row\"",
-                "name=\"resource:demo:foo:insert-row\"",
+                'name="all:insert-row"',
+                'name="resource:demo:foo:insert-row"',
             ],
-            ["name=\"all:delete-row\"", "name=\"resource:demo:foo:delete-row\""],
+            ['name="all:delete-row"', 'name="resource:demo:foo:delete-row"'],
         ),
     ],
     ids=[


### PR DESCRIPTION
> Clone simonw/datasette to /tmp and then read the plugin hook documentation in /tmp/datasette/docs/plugin-hooks.rst that covers the new register_token_handler() plugin - then upgrade this datasette-auth-tokens plugin to use the new mechanism, registering itself as a token handler

Upgrade the plugin to integrate with Datasette's new token handler system:

- Add ManagedTokenHandler class implementing TokenHandler with name="dsatok",
  providing create_token() and verify_token() methods for managed tokens
- Implement register_token_handler hook to register the handler when managed
  tokens mode is enabled
- Refactor actor_from_request to delegate Bearer token verification to
  Datasette's built-in handler (which calls verify_token() on all registered
  handlers), while still handling query param tokens directly
- Replace throwaway signed token hack in views.py with abbreviate_restrictions()
  utility for converting TokenRestrictions to abbreviated permission dicts
- Move abbreviate_restrictions helper to utils.py to avoid circular imports

https://claude.ai/code/session_01GXRh4RqkGvHwrniGfo9v6U