### PR TITLE
Add implementation plan for editable token permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,39 @@ A token can be revoked by the user that created it by clicking the "Revoke this 
 
 A user with the `auth-tokens-revoke-all` permission can revoke any token.
 
+### Editing token permissions
+
+The permissions (restrictions) of an existing token can be edited from the "Edit permissions" link on the token's page. A managed token is just a signed reference to a database row, and its restrictions are loaded fresh from that row on every request, so **editing a token's permissions takes effect immediately with no need to issue a replacement token**.
+
+Editing can only ever restrict a token to a subset of the permissions its owning actor already has.
+
+A token can be edited by the user that created it. A user with the `auth-tokens-edit-all` permission can edit any token.
+
+### Locking a token down to the permissions it actually used
+
+This plugin records which permission checks each token is used for, which enables a useful workflow:
+
+1. Issue a token with broad permissions.
+2. Use that token via the API to perform the actions you actually need it to perform.
+3. Open the token's "Edit permissions" page. A "Used in the last 5 minutes" panel lists the exact actions the token successfully exercised, with a "Lock down to only these permissions" button that restricts the token to just those actions.
+
+Token usage is recorded in an `auth_tokens_usage` table (stored in the same database as the tokens). For each token the plugin retains the larger of {the last 5 minutes of usage, the 200 most recent records}, capped at 1000 rows per token. The token's page also shows a "Recent usage" table of the most recent checks, including denied ones.
+
+This logging is on by default. To turn it off, set `"log_token_usage": false`:
+
+```json
+{
+    "plugins": {
+        "datasette-auth-tokens": {
+            "manage_tokens": true,
+            "log_token_usage": false
+        }
+    }
+}
+```
+
+Usage is captured by scanning Datasette's in-memory record of recent permission checks at the end of each request, so it is most reliable for the "issue a token, exercise it, then lock it down" workflow rather than as a complete long-term audit log.
+
 ## Hard-coded tokens
 
 Read about Datasette's [authentication and permissions system](https://datasette.readthedocs.io/en/latest/authentication.html).

--- a/README.md
+++ b/README.md
@@ -119,6 +119,21 @@ This logging is on by default. To turn it off, set `"log_token_usage": false`:
 
 Usage is captured by scanning Datasette's in-memory record of recent permission checks at the end of each request, so it is most reliable for the "issue a token, exercise it, then lock it down" workflow rather than as a complete long-term audit log.
 
+#### What usage tracking does and does not capture
+
+Usage tracking records the permission checks that Datasette runs when a token **accesses a specific resource** &mdash; reading a table or row, running a SQL query, inserting/updating/deleting data, and so on. These all go through the per-resource permission check that this plugin observes.
+
+It does **not** capture the checks behind Datasette's bulk "list the resources this actor can see" operations. Those power navigation and discovery rather than direct access, including:
+
+- The instance home page (listing the databases and tables you can see)
+- A database page's list of tables
+- The search / "jump to" menu
+- Lists of canned (stored) queries
+
+Datasette resolves these with a single SQL query rather than an individual check per resource, so they are invisible to usage tracking. The practical consequence: if a token is used **only** to list or browse resources (and never to access them directly), "lock down to only these permissions" may produce a token that is too restrictive &mdash; for example a token that only ever fetched the home page could be locked down to the point where that home page no longer lists anything.
+
+For this reason, treat the "used in the last 5 minutes" list as a **starting point**: review the permission checkboxes before saving, and add any list/browse permissions the token needs.
+
 ## Hard-coded tokens
 
 Read about Datasette's [authentication and permissions system](https://datasette.readthedocs.io/en/latest/authentication.html).

--- a/datasette_auth_tokens/__init__.py
+++ b/datasette_auth_tokens/__init__.py
@@ -1,6 +1,8 @@
 from datasette import hookimpl, Forbidden
 from datasette.permissions import Action
 from datasette.tokens import TokenHandler
+import datetime
+import functools
 import itsdangerous
 import json
 import secrets
@@ -15,6 +17,7 @@ from .views import (
     Config,
 )
 from .migrations import migration
+from .utils import prune_token_usage
 
 TOKEN_STATUSES = {
     "A": "Active",
@@ -235,6 +238,85 @@ def actor_from_request(datasette, request):
                 }
 
     return inner
+
+
+@hookimpl
+def asgi_wrapper(datasette):
+    def wrap(app):
+        @functools.wraps(app)
+        async def wrapped_app(scope, receive, send):
+            await app(scope, receive, send)
+            if scope["type"] == "http":
+                try:
+                    await _record_token_usage(datasette)
+                except Exception:
+                    # Usage logging must never break a request
+                    pass
+
+        return wrapped_app
+
+    return wrap
+
+
+def _iso_to_ms(when_iso):
+    return int(datetime.datetime.fromisoformat(when_iso).timestamp() * 1000)
+
+
+async def _record_token_usage(datasette):
+    """Drain new token-attributed permission checks from the in-memory deque
+    into the auth_tokens_usage table, then prune to the retention policy."""
+    config = Config(datasette)
+    if not config.enabled or not config.log_token_usage:
+        return
+    checks = list(getattr(datasette, "_permission_checks", []) or [])
+    if not checks:
+        return
+    high_water = getattr(datasette, "_auth_tokens_usage_high_water", "")
+    new_checks = [
+        check
+        for check in checks
+        if check.when > high_water
+        and check.actor
+        and check.actor.get("token_id") is not None
+    ]
+    # Advance past everything currently in the deque, even non-token checks
+    datasette._auth_tokens_usage_high_water = checks[-1].when
+    if not new_checks:
+        return
+
+    rows = []
+    token_ids = set()
+    for check in new_checks:
+        token_id = check.actor["token_id"]
+        token_ids.add(token_id)
+        rows.append(
+            {
+                "token_id": token_id,
+                "when_iso": check.when,
+                "created_ms": _iso_to_ms(check.when),
+                "action": check.action,
+                "parent": check.parent,
+                "child": check.child,
+                "result": 1 if check.result else 0,
+            }
+        )
+    now_ms = int(time.time() * 1000)
+
+    def write(conn):
+        with conn:
+            conn.executemany(
+                """
+                insert or ignore into auth_tokens_usage
+                    (token_id, when_iso, created_ms, action, parent, child, result)
+                values
+                    (:token_id, :when_iso, :created_ms, :action, :parent, :child, :result)
+                """,
+                rows,
+            )
+            for token_id in token_ids:
+                prune_token_usage(conn, token_id, now_ms)
+
+    await config.db.execute_write_fn(write)
 
 
 async def _actor_from_managed(datasette, incoming_token):

--- a/datasette_auth_tokens/__init__.py
+++ b/datasette_auth_tokens/__init__.py
@@ -14,6 +14,7 @@ from .views import (
     check_permission,
     tokens_index,
     token_details,
+    token_edit,
     Config,
 )
 from .migrations import migration
@@ -155,6 +156,7 @@ def register_routes(datasette):
         (r"^/-/api/tokens/create$", create_api_token),
         (r"^/-/api/tokens$", tokens_index),
         (r"^/-/api/tokens/(?P<id>\d+)$", token_details),
+        (r"^/-/api/tokens/(?P<id>\d+)/edit$", token_edit),
     ]
 
 
@@ -170,6 +172,11 @@ def register_actions(datasette):
             name="auth-tokens-view-all",
             abbr=None,
             description="View all API tokens",
+        ),
+        Action(
+            name="auth-tokens-edit-all",
+            abbr=None,
+            description="Edit permissions of any API tokens",
         ),
         Action(
             name="auth-tokens-create",

--- a/datasette_auth_tokens/migrations.py
+++ b/datasette_auth_tokens/migrations.py
@@ -64,3 +64,29 @@ def m003_add_ended_timestamp(db):
         set ended_timestamp = created_timestamp + expires_after_seconds
         where token_status = 'E'
         """)
+
+
+@migration()
+def m004_create_usage_table(db):
+    # Records which permission checks each token was used for, so we can offer
+    # a "lock this token down to what it actually used" feature.
+    db.execute("""
+    CREATE TABLE IF NOT EXISTS auth_tokens_usage (
+        id INTEGER PRIMARY KEY,
+        token_id INTEGER,        -- references _datasette_auth_tokens.id
+        when_iso TEXT,           -- PermissionCheck.when (ISO, microsecond)
+        created_ms INTEGER,      -- derived epoch ms, for range queries / pruning
+        action TEXT,
+        parent TEXT,             -- database, nullable
+        child TEXT,              -- table/resource, nullable
+        result INTEGER           -- 1 / 0
+    );
+    """)
+    db.execute("""
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_auth_tokens_usage_dedup
+        ON auth_tokens_usage (token_id, when_iso, action, parent, child);
+    """)
+    db.execute("""
+    CREATE INDEX IF NOT EXISTS idx_auth_tokens_usage_token_time
+        ON auth_tokens_usage (token_id, created_ms);
+    """)

--- a/datasette_auth_tokens/templates/edit_api_token.html
+++ b/datasette_auth_tokens/templates/edit_api_token.html
@@ -1,0 +1,138 @@
+{% extends "base.html" %}
+
+{% block title %}Edit API token{% if token.description %}: {{ token.description }}{% endif %}{% endblock %}
+
+{% block extra_head %}
+<style type="text/css">
+#restrict-permissions label {
+  display: inline;
+  width: 90%;
+}
+form div label {
+  /* Defaults to width: 15% which looks bad */
+  width: auto;
+}
+#suggested-usage {
+  border: 1px solid #ccc;
+  padding: 0.5em 1em;
+  margin-bottom: 1em;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+
+<h1>Edit API token: {{ token.id }}</h1>
+
+<p><a href="{{ urls.path('-/api/tokens/' + token.id|string) }}">Back to token</a> &middot; <a href="{{ urls.path('-/api/tokens') }}">List all tokens</a></p>
+
+<p>Editing these permissions takes effect immediately for the existing token &mdash; there is no need to issue a new one. Permissions can only ever restrict the token to a subset of what <strong>{{ request.actor.username or request.actor.id }}</strong> can already do.</p>
+
+{% if suggestions %}
+  <div id="suggested-usage">
+    <h2>Used in the last {{ usage_window_minutes }} minutes</h2>
+    <p>This token successfully used these {{ suggestions|length }} permission{{ "" if suggestions|length == 1 else "s" }}:</p>
+    <ul>
+      {% for suggestion in suggestions %}
+        <li>{{ suggestion.display }}</li>
+      {% endfor %}
+    </ul>
+    <button type="button" id="apply-suggestions">Lock down to only these permissions</button>
+  </div>
+{% endif %}
+
+<form class="core" action="{{ request.path }}" method="post">
+  <div>
+    <input type="submit" value="Save permissions">
+
+    <p style="margin-top: 1em" id="token-summary"></p>
+
+    <h2>All databases and tables</h2>
+    <ul>
+      {% for permission in all_permissions %}
+        <li><label><input type="checkbox" name="all:{{ permission.name }}"{% if "all:" + permission.name in checked_names %} checked{% endif %}> {{ permission.name }}</label> - {{ permission.description }}</li>
+      {% endfor %}
+    </ul>
+
+    {% for database in database_with_tables %}
+      <h2>All tables in "{{ database.name }}"</h2>
+      <ul>
+        {% for permission in database_permissions %}
+          <li><label><input type="checkbox" name="database:{{ database.encoded }}:{{ permission.name }}"{% if "database:" + database.encoded + ":" + permission.name in checked_names %} checked{% endif %}> {{ permission.name }}</label> - {{ permission.description }}</li>
+        {% endfor %}
+        {% if database.tables %}
+          {% for permission in resource_permissions %}
+            <li><label><input type="checkbox" name="database:{{ database.encoded }}:{{ permission.name }}"{% if "database:" + database.encoded + ":" + permission.name in checked_names %} checked{% endif %}> {{ permission.name }}</label> - {{ permission.description }}</li>
+          {% endfor %}
+        {% endif %}
+      </ul>
+    {% endfor %}
+    {% if databases_with_at_least_one_table %}
+    <h2>Specific tables in specific databases</h2>
+    {% for database in databases_with_at_least_one_table %}
+      {% for table in database.tables %}
+        <h3>{{ database.name }}: {{ table.name }}</h3>
+        <ul>
+          {% for permission in resource_permissions %}
+            <li><label><input type="checkbox" name="resource:{{ database.encoded }}:{{ table.encoded }}:{{ permission.name }}"{% if "resource:" + database.encoded + ":" + table.encoded + ":" + permission.name in checked_names %} checked{% endif %}> {{ permission.name }}</label> - {{ permission.description }}</li>
+          {% endfor %}
+        </ul>
+      {% endfor %}
+    {% endfor %}
+    {% endif %}
+</form>
+</div>
+
+<script>
+var suggestedNames = {{ suggestions|map(attribute="name")|list|tojson }};
+
+function updateTokenSummary() {
+  var allChecked = document.querySelectorAll('input[type="checkbox"]:checked');
+  var checkedValues = [];
+  for (var i = 0; i < allChecked.length; i++) {
+    checkedValues.push(humanPermission(allChecked[i].name));
+  }
+  var tokenSummary = document.querySelector('#token-summary');
+  if (checkedValues.length == 0) {
+    tokenSummary.innerHTML = 'Token will have all of the permissions of your current user';
+  } else {
+    let html = ['<ul style="margin-top: 0.5em">'];
+    checkedValues.forEach(function(value) {
+      html.push('<li style="list-style-type: disc; margin-left: 1em;">' + value + '</li>');
+    });
+    html.push('</ul>');
+    tokenSummary.innerHTML = 'Token will be restricted to: ' + html.join('');
+  }
+}
+
+function humanPermission(permission) {
+  var parts = permission.split(':');
+  var type = parts[0];
+  var db = parts[1];
+  var action = parts[parts.length - 1];
+  if (type == 'all') {
+    return 'all databases and tables: ' + action;
+  } else if (type == 'database') {
+    return db + ' database: ' + action;
+  } else if (type == 'resource') {
+    var table = parts[2];
+    return db + '/' + table + ' table: ' + action;
+  }
+}
+
+var applyButton = document.querySelector('#apply-suggestions');
+if (applyButton) {
+  applyButton.addEventListener('click', function() {
+    var wanted = new Set(suggestedNames);
+    document.querySelectorAll('input[type="checkbox"]').forEach(function(box) {
+      box.checked = wanted.has(box.name);
+    });
+    updateTokenSummary();
+  });
+}
+
+document.addEventListener('change', updateTokenSummary);
+updateTokenSummary();
+</script>
+
+{% endblock %}

--- a/datasette_auth_tokens/templates/edit_api_token.html
+++ b/datasette_auth_tokens/templates/edit_api_token.html
@@ -38,6 +38,7 @@ form div label {
       {% endfor %}
     </ul>
     <button type="button" id="apply-suggestions">Lock down to only these permissions</button>
+    <p style="margin-top: 0.75em; font-size: 0.9em; color: #555;">This list only covers resources the token <strong>accessed directly</strong>. Actions it used only to <em>list or browse</em> resources &mdash; the home page, a database's table list, the search/jump menu &mdash; are not captured here, so review the checkboxes below before saving.</p>
   </div>
 {% endif %}
 

--- a/datasette_auth_tokens/templates/token_details.html
+++ b/datasette_auth_tokens/templates/token_details.html
@@ -36,6 +36,30 @@ dd {
     <dd><pre>{{ restrictions }}</pre></dd>
 </dl>
 
+{% if can_edit %}
+<p><a href="{{ token.id }}/edit">Edit permissions</a></p>
+{% endif %}
+
+{% if recent_checks %}
+<h2>Recent usage</h2>
+<p>The most recent permission checks made using this token.</p>
+<table class="rows-and-columns">
+    <thead>
+        <tr><th>When</th><th>Action</th><th>Resource</th><th>Result</th></tr>
+    </thead>
+    <tbody>
+        {% for check in recent_checks %}
+        <tr>
+            <td>{{ check.when_iso }}</td>
+            <td>{{ check.action }}</td>
+            <td>{% if check.child %}{{ check.parent }}/{{ check.child }}{% elif check.parent %}{{ check.parent }}{% else %}(instance){% endif %}</td>
+            <td>{{ "allowed" if check.result else "denied" }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endif %}
+
 {% if token_status == "Active" and can_revoke %}
 <br>
 <form class="core" action="{{ request.path }}" method="POST">

--- a/datasette_auth_tokens/utils.py
+++ b/datasette_auth_tokens/utils.py
@@ -1,3 +1,4 @@
+from datasette.utils import tilde_encode
 from typing import Optional
 import time
 
@@ -81,13 +82,117 @@ def ago_difference(time1: int, time2: Optional[int] = None):
         return "{} ago".format(combined)
 
 
+def abbr_to_name(datasette):
+    """Map each action's abbreviation back to its full name."""
+    return {
+        action.abbr: action.name
+        for action in datasette.actions.values()
+        if action.abbr
+    }
+
+
+def checkbox_names_from_permissions(datasette, permissions):
+    """Reverse an abbreviated _r permissions dict into the set of checkbox
+    `name` strings used by the create/edit token forms, so a form can be
+    pre-checked to match a token's current restrictions."""
+    if not permissions:
+        return set()
+    abbreviations = abbr_to_name(datasette)
+
+    def name(code):
+        return abbreviations.get(code, code)
+
+    names = set()
+    for code in permissions.get("a", []):
+        names.add("all:{}".format(name(code)))
+    for database, codes in permissions.get("d", {}).items():
+        for code in codes:
+            names.add("database:{}:{}".format(tilde_encode(database), name(code)))
+    for database, tables in permissions.get("r", {}).items():
+        for table, codes in tables.items():
+            for code in codes:
+                names.add(
+                    "resource:{}:{}:{}".format(
+                        tilde_encode(database), tilde_encode(table), name(code)
+                    )
+                )
+    return names
+
+
+def _usage_suggestion(action, parent, child):
+    """Map a (action, parent, child) usage row to a checkbox name + display."""
+    if child is not None:
+        return {
+            "name": "resource:{}:{}:{}".format(
+                tilde_encode(parent), tilde_encode(child), action
+            ),
+            "display": "{}/{} table: {}".format(parent, child, action),
+            "action": action,
+            "parent": parent,
+            "child": child,
+        }
+    if parent is not None:
+        return {
+            "name": "database:{}:{}".format(tilde_encode(parent), action),
+            "display": "{} database: {}".format(parent, action),
+            "action": action,
+            "parent": parent,
+            "child": child,
+        }
+    return {
+        "name": "all:{}".format(action),
+        "display": "all databases and tables: {}".format(action),
+        "action": action,
+        "parent": parent,
+        "child": child,
+    }
+
+
+async def recent_token_usage(datasette, token_id, within_seconds=USAGE_RETENTION_SECONDS):
+    """Distinct actions a token successfully exercised within the time window,
+    as form-checkbox suggestions for the "lock it down" feature."""
+    from .views import Config
+
+    db = Config(datasette).db
+    cutoff_ms = int((time.time() - within_seconds) * 1000)
+    rows = (
+        await db.execute(
+            """
+            select distinct action, parent, child
+            from auth_tokens_usage
+            where token_id = :token_id and result = 1 and created_ms >= :cutoff
+            order by action, parent, child
+            """,
+            {"token_id": token_id, "cutoff": cutoff_ms},
+        )
+    ).rows
+    return [_usage_suggestion(row["action"], row["parent"], row["child"]) for row in rows]
+
+
+async def recent_token_checks(datasette, token_id, limit=50):
+    """Most recent permission checks for a token (including denied ones), for
+    display on the token details page."""
+    from .views import Config
+
+    db = Config(datasette).db
+    rows = (
+        await db.execute(
+            """
+            select action, parent, child, result, when_iso, created_ms
+            from auth_tokens_usage
+            where token_id = :token_id
+            order by id desc limit :limit
+            """,
+            {"token_id": token_id, "limit": limit},
+        )
+    ).rows
+    return [dict(row) for row in rows]
+
+
 def format_permissions(datasette, permissions_dict):
     if not permissions_dict:
         return "All permissions"
-    abbreviations = {}
-    for action in datasette.actions.values():
-        if action.abbr:
-            abbreviations[action.abbr] = action.name
+    abbreviations = abbr_to_name(datasette)
 
     output = []
 

--- a/datasette_auth_tokens/utils.py
+++ b/datasette_auth_tokens/utils.py
@@ -1,6 +1,43 @@
 from typing import Optional
 import time
 
+# Per token, retain the larger of {last 5 minutes, newest 200 records}, capped
+# at 1000 rows total.
+USAGE_RETENTION_SECONDS = 5 * 60
+USAGE_RETENTION_MS = USAGE_RETENTION_SECONDS * 1000
+USAGE_RETENTION_RECENT_RECORDS = 200
+USAGE_RETENTION_MAX_RECORDS = 1000
+
+
+def prune_token_usage(conn, token_id, now_ms):
+    """Trim auth_tokens_usage rows for a single token to the retention policy.
+
+    Keeps the union of {rows within the last 5 minutes} and {the newest 200
+    rows}, then caps that union at the newest 1000 rows, deleting the rest.
+    """
+    conn.execute(
+        """
+        DELETE FROM auth_tokens_usage
+        WHERE token_id = :tid AND id NOT IN (
+            SELECT id FROM auth_tokens_usage
+            WHERE token_id = :tid AND (
+                created_ms >= :five_min_ago
+                OR id IN (
+                    SELECT id FROM auth_tokens_usage
+                    WHERE token_id = :tid ORDER BY id DESC LIMIT :recent
+                )
+            )
+            ORDER BY id DESC LIMIT :cap
+        )
+        """,
+        {
+            "tid": token_id,
+            "five_min_ago": now_ms - USAGE_RETENTION_MS,
+            "recent": USAGE_RETENTION_RECENT_RECORDS,
+            "cap": USAGE_RETENTION_MAX_RECORDS,
+        },
+    )
+
 
 def pluralize(n, unit):
     return f"{n} {unit}" if n == 1 else f"{n} {unit}s"

--- a/datasette_auth_tokens/views.py
+++ b/datasette_auth_tokens/views.py
@@ -6,10 +6,33 @@ from datasette.utils import (
     tilde_decode,
     display_actor,
 )
-from .utils import ago_difference, format_permissions
+from .utils import (
+    ago_difference,
+    format_permissions,
+    checkbox_names_from_permissions,
+    recent_token_usage,
+    recent_token_checks,
+)
 import datetime
 import json
 import time
+
+
+def parse_restrictions_from_post(datasette, post):
+    """Build a TokenRestrictions from the create/edit form's checkbox names."""
+    restrictions = TokenRestrictions()
+    for key in post:
+        if key.startswith("all:") and key.count(":") == 1:
+            restrictions.allow_all(key.split(":")[1])
+        elif key.startswith("database:") and key.count(":") == 2:
+            bits = key.split(":")
+            restrictions.allow_database(tilde_decode(bits[1]), bits[2])
+        elif key.startswith("resource:") and key.count(":") == 3:
+            bits = key.split(":")
+            restrictions.allow_resource(
+                tilde_decode(bits[1]), tilde_decode(bits[2]), bits[3]
+            )
+    return restrictions
 
 TOKEN_PAGE_SIZE = 30
 
@@ -48,22 +71,7 @@ async def create_api_token(request, datasette):
                     errors.append("Invalid expire duration unit")
 
         # Are there any restrictions?
-        restrictions = TokenRestrictions()
-
-        for key in post:
-            if key.startswith("all:") and key.count(":") == 1:
-                restrictions.allow_all(key.split(":")[1])
-            elif key.startswith("database:") and key.count(":") == 2:
-                bits = key.split(":")
-                database = tilde_decode(bits[1])
-                action = bits[2]
-                restrictions.allow_database(database, action)
-            elif key.startswith("resource:") and key.count(":") == 3:
-                bits = key.split(":")
-                database = tilde_decode(bits[1])
-                resource = tilde_decode(bits[2])
-                action = bits[3]
-                restrictions.allow_resource(database, resource, action)
+        restrictions = parse_restrictions_from_post(datasette, post)
 
         from . import _abbreviate_restrictions
 
@@ -116,7 +124,6 @@ async def check_permission(datasette, actor):
 
 
 async def _shared(datasette, request):
-    await check_permission(datasette, request.actor)
     db = Config(datasette).db
 
     tokens_exist = bool(
@@ -287,6 +294,7 @@ async def token_details(request, datasette):
         raise Forbidden("You do not have permission to manage this token")
 
     can_revoke = await actor_can_revoke(datasette, request.actor, row["actor_id"])
+    can_edit = await actor_can_edit(datasette, request.actor, row["actor_id"])
 
     if (
         row["expires_after_seconds"]
@@ -326,6 +334,8 @@ async def token_details(request, datasette):
     if actors and actors.get(row["actor_id"]):
         actor_display = display_actor(actors[row["actor_id"]])
 
+    recent_checks = await recent_token_checks(datasette, row["id"])
+
     return Response.html(
         await datasette.render_template(
             "token_details.html",
@@ -339,8 +349,56 @@ async def token_details(request, datasette):
                 "ago_difference": ago_difference,
                 "restrictions": restrictions,
                 "can_revoke": can_revoke,
+                "can_edit": can_edit and row["token_status"] == "A",
+                "recent_checks": recent_checks,
             },
             request=request,
+        )
+    )
+
+
+async def token_edit(request, datasette):
+    from . import _abbreviate_restrictions
+
+    config = Config(datasette)
+    db = config.db
+    id = request.url_vars["id"]
+
+    row = (
+        await db.execute("select * from _datasette_auth_tokens where id = ?", (id,))
+    ).first()
+    if row is None:
+        raise NotFound("Token not found")
+
+    if not await actor_can_edit(datasette, request.actor, row["actor_id"]):
+        raise Forbidden("You do not have permission to edit this token")
+
+    if row["token_status"] != "A":
+        raise Forbidden("Cannot edit a revoked or expired token")
+
+    if request.method == "POST":
+        post = await request.post_vars()
+        restrictions = parse_restrictions_from_post(datasette, post)
+        permissions = _abbreviate_restrictions(datasette, restrictions)
+        await db.execute_write(
+            "update _datasette_auth_tokens set permissions = :permissions where id = :id",
+            {"permissions": json.dumps(permissions), "id": id},
+        )
+        return Response.redirect(datasette.urls.path("/-/api/tokens/{}".format(id)))
+
+    context = await _shared(datasette, request)
+    current = json.loads(row["permissions"])
+    context.update(
+        {
+            "token": row,
+            "checked_names": checkbox_names_from_permissions(datasette, current),
+            "suggestions": await recent_token_usage(datasette, row["id"]),
+            "usage_window_minutes": 5,
+        }
+    )
+    return Response.html(
+        await datasette.render_template(
+            "edit_api_token.html", context, request=request
         )
     )
 
@@ -370,6 +428,16 @@ async def actor_can_revoke(datasette, actor, token_actor_id):
         return True
     # User with auth-tokens-revoke-all can revoke any token
     return await datasette.allowed(action="auth-tokens-revoke-all", actor=actor)
+
+
+async def actor_can_edit(datasette, actor, token_actor_id):
+    if not actor or not actor.get("id"):
+        # Only works for actors that have an ID set
+        return False
+    if token_actor_id and str(token_actor_id) == str(actor.get("id")):
+        return True
+    # User with auth-tokens-edit-all can edit any token
+    return await datasette.allowed(action="auth-tokens-edit-all", actor=actor)
 
 
 class Config:

--- a/datasette_auth_tokens/views.py
+++ b/datasette_auth_tokens/views.py
@@ -377,6 +377,7 @@ class Config:
         self._plugin_config = datasette.plugin_config("datasette-auth-tokens") or {}
         self._datasette = datasette
         self.enabled = self._plugin_config.get("manage_tokens")
+        self.log_token_usage = self._plugin_config.get("log_token_usage", True)
 
     def get(self, key):
         return self._plugin_config.get(key)

--- a/docs/plan-editable-token-permissions.md
+++ b/docs/plan-editable-token-permissions.md
@@ -1,0 +1,246 @@
+# Plan: Edit token permissions + "lock down to recently-used actions"
+
+## Context
+
+`datasette-auth-tokens` managed (database-backed) tokens currently support
+**create**, **view**, and **revoke** — but a token's permissions are fixed at
+creation time. The token details page (`/-/api/tokens/{id}`) shows restrictions
+read-only.
+
+A token's *effective* permissions are not baked into the token string. The token
+is just a signed row id (`dsatok_<signed id>`); on every request
+`_actor_from_managed()` loads the row's `permissions` JSON column into
+`actor["_r"]` (`datasette_auth_tokens/__init__.py:267-269`). **This means
+editing the `permissions` column changes the token's powers immediately, with no
+re-issuing.** That property makes this feature natural to build, and enables the
+second goal below.
+
+This plan delivers two things:
+
+1. **Edit the permissions of an existing token** via a new edit page.
+2. **A "lock it down" workflow**: issue a wide token, exercise it via the API,
+   then the edit page surfaces *"in the last 10 minutes this token used these
+   exact actions — restrict it to only those?"*
+
+Decisions confirmed with the user:
+- **Usage capture** = at the end of every request, an `asgi_wrapper` scans
+  Datasette's in-memory `datasette._permission_checks` deque for checks whose
+  actor carries a `token_id` and **persists them to a new plugin-managed table**
+  (`auth_tokens_usage`). On by default, disableable via a config
+  setting. This makes usage durable (survives restarts, shared across workers via
+  the shared SQLite table) — the deque is only the per-request source. Retention:
+  per token, keep the **larger** of {last 5 minutes of data, 200 most recent
+  records}, with a **hard cap of 1000 rows per token**.
+- **Edit authorization** = a new dedicated action (named `auth-tokens-edit-all`
+  to match the existing `-all` convention — owner can always edit their own
+  token; this action lets an admin edit *others'* tokens, mirroring
+  `auth-tokens-revoke-all`).
+
+## How Datasette records permission checks (key fact)
+
+In Datasette 1.0a20+ the old `permission_allowed` hook is gone. Every
+`await datasette.allowed(action=, resource=, actor=)` call appends a
+`PermissionCheck(when, actor, action, parent, child, result)` to
+`datasette._permission_checks` (a `collections.deque(maxlen=200)`):
+- `when` — ISO timestamp
+- `actor` — the actor dict at check time (for our tokens this includes
+  `token_id`, set in `__init__.py:262-266`)
+- `action` — e.g. `view-table`
+- `parent` / `child` — database / table (either may be `None`)
+- `result` — bool
+
+So checks made on requests authenticated by a managed token are attributable via
+`check.actor.get("token_id")`, and `parent`/`child` give db/table granularity.
+
+## Implementation workflow
+- **Red/green TDD**: for each unit of behavior, write a failing test first, run
+  `uv run pytest` to see it fail (red), implement the minimum to pass (green),
+  then refactor. Work in this order: migration/table → asgi_wrapper capture
+  (insert → dedup → prune) → read helpers → edit route → templates.
+- **Frequent small commits** on `claude/database-token-permissions-fkky63`, each
+  with a multi-line commit message (subject line + body explaining the change).
+  Push at the end.
+
+## Changes
+
+### 1. New action `auth-tokens-edit-all`
+`datasette_auth_tokens/__init__.py` — add to `register_actions()` (alongside the
+existing three, `__init__.py:159-176`):
+```python
+Action(name="auth-tokens-edit-all", abbr=None,
+       description="Edit permissions of any API tokens"),
+```
+
+### 2. Authorization helper
+`datasette_auth_tokens/views.py` — add `actor_can_edit(datasette, actor,
+token_actor_id)` modeled exactly on `actor_can_revoke` (`views.py:365-372`):
+owner (`actor.id == token.actor_id`) OR `auth-tokens-edit-all`.
+
+### 3. Refactor restriction parsing (reuse, don't duplicate)
+The checkbox-name → `TokenRestrictions` parsing currently lives inline in
+`create_api_token` (`views.py:50-66`). Extract it to a reusable helper, e.g.
+`parse_restrictions_from_post(datasette, post) -> TokenRestrictions`, and call it
+from both create and edit. Keeps the `all:` / `database:<db>:` /
+`resource:<db>:<table>:` name format and `tilde_decode` handling identical.
+
+### 4. Reverse mapping: stored permissions → pre-checked boxes
+Add a helper to turn the stored **abbreviated** `permissions` dict back into the
+set of checkbox `name` strings, so the edit form pre-checks current settings.
+Reuse the abbr→name map that `format_permissions` already builds
+(`utils.py:50-53`) — factor it into a small `abbr_to_name(datasette)` helper in
+`utils.py` and use it in both places.
+```
+{"a":[abbr]}            -> all:<name>
+{"d":{db:[abbr]}}       -> database:<tilde_encode(db)>:<name>
+{"r":{db:{tbl:[abbr]}}} -> resource:<tilde_encode(db)>:<tilde_encode(tbl)>:<name>
+```
+
+### 5. Persist usage: new table + asgi_wrapper (feature 2 capture layer)
+
+**Migration** — add `m004_create_usage_table` to `datasette_auth_tokens/migrations.py`
+(applied by the existing `startup` hook, `__init__.py:128-143`):
+```sql
+CREATE TABLE IF NOT EXISTS auth_tokens_usage (
+    id INTEGER PRIMARY KEY,
+    token_id INTEGER,        -- references _datasette_auth_tokens.id
+    when_iso TEXT,           -- PermissionCheck.when (ISO, microsecond)
+    created_ms INTEGER,      -- derived epoch ms, for range queries / pruning
+    action TEXT,
+    parent TEXT,             -- database, nullable
+    child TEXT,              -- table/resource, nullable
+    result INTEGER           -- 1 / 0
+);
+-- dedup backstop:
+CREATE UNIQUE INDEX IF NOT EXISTS idx_usage_dedup
+    ON auth_tokens_usage (token_id, when_iso, action, parent, child);
+CREATE INDEX IF NOT EXISTS idx_usage_token_time
+    ON auth_tokens_usage (token_id, created_ms);
+```
+
+**`asgi_wrapper(datasette)` hook** in `__init__.py` (gated on `Config.enabled`
+and a new `log_token_usage` setting defaulting to `True`):
+- Wrap the app; for `scope["type"] == "http"`, after `await app(...)` returns,
+  drain new token checks. Source = `datasette._permission_checks`.
+- **Dedup**: keep a per-process high-water `when_iso`; process only deque entries
+  with `when > high_water` and `actor and actor.get("token_id")`; advance the
+  high-water. `INSERT OR IGNORE` (unique index) is the backstop for restarts /
+  concurrency.
+- Insert each as a row (parse `when` → `created_ms`). Skip the write entirely
+  when there are no new token checks.
+- **Prune** only the token_ids just touched (cheap). Per token_id, keep the union
+  of {`created_ms >= now-5min`} and {newest 200 by `id`}, then cap that union at
+  the newest 1000, deleting the rest:
+  ```sql
+  DELETE FROM auth_tokens_usage
+  WHERE token_id = :tid AND id NOT IN (
+    SELECT id FROM auth_tokens_usage
+    WHERE token_id = :tid AND (
+        created_ms >= :five_min_ago
+        OR id IN (SELECT id FROM auth_tokens_usage
+                  WHERE token_id = :tid ORDER BY id DESC LIMIT 200)
+    )
+    ORDER BY id DESC LIMIT 1000
+  );
+  ```
+- Writes go through `Config.db` via `execute_write` / `execute_write_fn`.
+
+### 6. Usage aggregation helper (feature 2 read layer)
+Add `recent_token_usage(datasette, token_id, within_seconds=300)` in `utils.py`,
+querying `auth_tokens_usage` (not the deque):
+- `SELECT DISTINCT action, parent, child` for `token_id`, `result = 1`,
+  `created_ms >= now - within_seconds` (only actions the token *successfully*
+  used — denied attempts are excluded from the suggestion).
+- Map each to a checkbox name (same vocabulary as the form):
+  - `child` set → `resource:<db>:<table>:<action>`
+  - `parent` only → `database:<db>:<action>`
+  - neither → `all:<action>` (instance-level actions; document this mapping)
+- Return the set of suggested checkbox names plus a human-readable list.
+- Also expose a `recent_token_checks(datasette, token_id, limit)` for the
+  details page that returns *all* recent rows (incl. denied) for transparency.
+
+### 7. New edit route + view
+`__init__.py` `register_routes()` (`__init__.py:151-155`) — add:
+```python
+(r"^/-/api/tokens/(?P<id>\d+)/edit$", token_edit),
+```
+`views.py` — add `token_edit(request, datasette)`:
+- Fetch row; `NotFound` if missing; require `actor_can_edit`; only allow editing
+  **Active** tokens.
+- **GET**: build `_shared()` context (`views.py:118` — reuses the same
+  database/table/permission lists as create), add `checked_names` (helper #4) and
+  `suggested` usage names + display (helper #5), render `edit_api_token.html`.
+- **POST**: `parse_restrictions_from_post` (helper #3) →
+  `_abbreviate_restrictions(datasette, restrictions)` (`__init__.py:28`) →
+  `UPDATE _datasette_auth_tokens SET permissions=:permissions WHERE id=:id`,
+  then redirect to the details page. Restrictions only ever *narrow* what the
+  owning actor can already do, so no extra privilege check on the chosen set is
+  needed.
+
+### 8. Templates
+- New `templates/edit_api_token.html`: clone the checkbox sections + summary JS
+  from `create_api_token.html` (`templates/create_api_token.html:67-99,103-159`),
+  but: pre-check inputs whose `name` is in `checked_names`; drop the
+  expiry/description and one-time-token issuance blocks; POST to the edit URL.
+  Add a **"Used in the last 5 minutes"** panel listing `suggested` actions with
+  an **"Apply these restrictions"** button — clicking it sets the checkboxes to
+  exactly the suggested set (small JS using the existing names), so the user can
+  review before saving. Reuse the existing `updateTokenSummary()` JS.
+- `templates/token_details.html`: add an **"Edit permissions"** link to
+  `{id}/edit` shown when `token_status == "Active"` and the actor can edit
+  (pass a `can_edit` flag from `token_details`, `views.py:289`), plus a
+  **"Recent usage"** list (from `recent_token_checks`) showing the last actions
+  this token was checked against, including denied ones.
+
+### 9. Docs
+`README.md` — document the edit page, the `auth-tokens-edit-all` action, the
+`log_token_usage` setting + retention rules, and the "lock down to
+recently-used permissions" workflow.
+
+## Files
+- `datasette_auth_tokens/__init__.py` — new `auth-tokens-edit-all` action, new
+  edit route, `asgi_wrapper` usage-capture hook.
+- `datasette_auth_tokens/migrations.py` — `m004_create_usage_table`.
+- `datasette_auth_tokens/views.py` — `token_edit`, `actor_can_edit`,
+  `parse_restrictions_from_post`, wire `can_edit` + recent usage into
+  `token_details`, `Config.log_token_usage`.
+- `datasette_auth_tokens/utils.py` — `abbr_to_name`, reverse-checkbox helper,
+  `recent_token_usage`, `recent_token_checks`.
+- `datasette_auth_tokens/templates/edit_api_token.html` — new.
+- `datasette_auth_tokens/templates/token_details.html` — edit link + recent usage.
+- `tests/test_managed_tokens.py` — new tests.
+- `README.md` — docs.
+
+## Limitations / notes
+- The capture *source* is still the private, in-memory `_permission_checks` deque
+  (capped at 200 total across all actors), drained per request. Persisting to the
+  table removes the volatility for the read side, but if a **single request**
+  generates >200 checks for one token, the earliest could be evicted before the
+  request ends (rare). Checks are only captured for requests handled by a process
+  running this plugin (i.e. requests authenticated by the token).
+- Writing on each request that produced new token checks adds one small write;
+  fully skipped when `log_token_usage` is off or there are no new token checks.
+
+## Verification
+- **Tests** (`tests/test_managed_tokens.py`, existing `Datasette`/
+  `pytest-asyncio` fixtures e.g. `ds_managed`):
+  - GET `/-/api/tokens/{id}/edit` pre-checks current restrictions.
+  - POST updates the `permissions` column **and** changes the token's effective
+    `_r` (verify via an authenticated API call before/after).
+  - `auth-tokens-edit-all` gating: owner edits own; non-owner needs the action;
+    editing a revoked/expired token is rejected.
+  - Capture: make authenticated requests (e.g. `GET` a table with `Authorization:
+    Bearer dsatok_…`), then assert rows land in `auth_tokens_usage`
+    with the right `token_id`/`action`/`parent`/`child`/`result`; assert dedup
+    (repeat requests don't double-insert) and pruning (synthesize >1000 rows /
+    old rows → capped/trimmed per the rules).
+  - Suggestion + apply: after exercising a wide token, assert
+    `recent_token_usage()` / the rendered panel reflects exactly the exercised
+    actions, and "Apply" → save writes the matching abbreviated `permissions`.
+  - `log_token_usage: false` disables capture (no rows written).
+  - Run: `python -m pytest tests/test_managed_tokens.py -x` (datasette is not yet
+    installed in this env — `pip install -e '.[dev]'` first, or rely on CI).
+- **Manual**: run with `manage_tokens: true` and `auth-tokens-create` granted;
+  create a wide token, `curl -H "Authorization: Bearer dsatok_…"` a table, open
+  `/-/api/tokens/{id}/edit`, confirm the "Used in the last 5 minutes" panel lists
+  `view-table` on that db/table, click Apply + Save, then confirm the token is
+  now restricted (a `curl` to a different table returns 403).

--- a/tests/test_managed_tokens.py
+++ b/tests/test_managed_tokens.py
@@ -44,6 +44,7 @@ async def ds_managed(db_path):
             "permissions": {
                 "auth-tokens-revoke-all": {"id": "admin"},
                 "auth-tokens-view-all": {"id": "admin"},
+                "auth-tokens-edit-all": {"id": "admin"},
                 "auth-tokens-create": {"id": "*"},
             },
         },
@@ -626,6 +627,109 @@ async def test_recent_token_usage_suggestions(ds_managed):
     assert "resource:demo:foo:view-table" in names
     # Each suggestion carries a human-readable display string
     assert all(s["display"] for s in suggestions)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scenario,allowed",
+    (
+        ("owner", True),
+        ("admin", True),
+        ("other-user", False),
+        ("anonymous", False),
+    ),
+)
+async def test_edit_token_gating(ds_managed, scenario, allowed):
+    token_id, _ = await _create_token(ds_managed, "owner")
+    if scenario == "anonymous":
+        cookies = {}
+    else:
+        cookies = {"ds_actor": ds_managed.client.actor_cookie({"id": scenario})}
+    response = await ds_managed.client.get(
+        "/-/api/tokens/{}/edit".format(token_id), cookies=cookies
+    )
+    assert response.status_code == (200 if allowed else 403)
+
+
+@pytest.mark.asyncio
+async def test_edit_token_updates_permissions(ds_managed):
+    token_id, token = await _create_token(ds_managed, "owner")
+    cookies = {"ds_actor": ds_managed.client.actor_cookie({"id": "owner"})}
+    response = await ds_managed.client.post(
+        "/-/api/tokens/{}/edit".format(token_id),
+        data={"resource:demo:foo:view-table": "1"},
+        cookies=cookies,
+    )
+    assert response.status_code == 302
+    row = (
+        await ds_managed.get_internal_database().execute(
+            "select permissions from _datasette_auth_tokens where id=:id",
+            {"id": token_id},
+        )
+    ).first()
+    assert json.loads(row["permissions"]) == {"r": {"demo": {"foo": ["vt"]}}}
+    # Effective restrictions change immediately, no re-issue needed
+    actor_response = await ds_managed.client.get(
+        "/-/actor.json", headers={"Authorization": "Bearer {}".format(token)}
+    )
+    assert actor_response.json()["actor"]["_r"] == {"r": {"demo": {"foo": ["vt"]}}}
+
+
+@pytest.mark.asyncio
+async def test_edit_token_form_prechecks_current_restrictions(ds_managed):
+    await ds_managed.invoke_startup()
+    handler = ManagedTokenHandler()
+    token = await handler.create_token(
+        ds_managed,
+        "owner",
+        restrictions=TokenRestrictions().allow_resource("demo", "foo", "view-table"),
+    )
+    token_id = ds_managed.unsign(token[len("dsatok_") :], namespace="dsatok")
+    cookies = {"ds_actor": ds_managed.client.actor_cookie({"id": "owner"})}
+    response = await ds_managed.client.get(
+        "/-/api/tokens/{}/edit".format(token_id), cookies=cookies
+    )
+    assert response.status_code == 200
+    assert 'name="resource:demo:foo:view-table" checked' in response.text
+
+
+@pytest.mark.asyncio
+async def test_edit_revoked_token_forbidden(ds_managed):
+    token_id, _ = await _create_token(ds_managed, "owner")
+    await ds_managed.get_internal_database().execute_write(
+        "update _datasette_auth_tokens set token_status='R' where id=:id",
+        {"id": token_id},
+    )
+    cookies = {"ds_actor": ds_managed.client.actor_cookie({"id": "owner"})}
+    response = await ds_managed.client.get(
+        "/-/api/tokens/{}/edit".format(token_id), cookies=cookies
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_edit_page_shows_recent_usage_suggestion(ds_managed):
+    token_id, token = await _create_token(ds_managed, "owner")
+    await ds_managed.client.get(
+        "/demo/foo.json", headers={"Authorization": "Bearer {}".format(token)}
+    )
+    cookies = {"ds_actor": ds_managed.client.actor_cookie({"id": "owner"})}
+    response = await ds_managed.client.get(
+        "/-/api/tokens/{}/edit".format(token_id), cookies=cookies
+    )
+    assert response.status_code == 200
+    assert "Used in the last" in response.text
+    assert "demo/foo table: view-table" in response.text
+
+
+@pytest.mark.asyncio
+async def test_details_page_has_edit_link(ds_managed):
+    token_id, _ = await _create_token(ds_managed, "owner")
+    cookies = {"ds_actor": ds_managed.client.actor_cookie({"id": "owner"})}
+    response = await ds_managed.client.get(
+        "/-/api/tokens/{}".format(token_id), cookies=cookies
+    )
+    assert 'href="{}/edit"'.format(token_id) in response.text
 
 
 async def _usage_rows(ds, token_id):

--- a/tests/test_managed_tokens.py
+++ b/tests/test_managed_tokens.py
@@ -591,6 +591,43 @@ async def test_handler_create_token_stores_abbreviated_r(ds_managed):
     }
 
 
+@pytest.mark.asyncio
+async def test_checkbox_names_from_permissions(ds_managed):
+    from datasette_auth_tokens.utils import checkbox_names_from_permissions
+
+    await ds_managed.invoke_startup()
+    permissions = {"a": ["vi"], "d": {"demo": ["ir"]}, "r": {"demo": {"foo": ["vt"]}}}
+    names = checkbox_names_from_permissions(ds_managed, permissions)
+    assert names == {
+        "all:view-instance",
+        "database:demo:insert-row",
+        "resource:demo:foo:view-table",
+    }
+
+
+@pytest.mark.asyncio
+async def test_checkbox_names_from_permissions_empty(ds_managed):
+    from datasette_auth_tokens.utils import checkbox_names_from_permissions
+
+    await ds_managed.invoke_startup()
+    assert checkbox_names_from_permissions(ds_managed, None) == set()
+
+
+@pytest.mark.asyncio
+async def test_recent_token_usage_suggestions(ds_managed):
+    from datasette_auth_tokens.utils import recent_token_usage
+
+    token_id, token = await _create_token(ds_managed)
+    await ds_managed.client.get(
+        "/demo/foo.json", headers={"Authorization": "Bearer {}".format(token)}
+    )
+    suggestions = await recent_token_usage(ds_managed, token_id)
+    names = {s["name"] for s in suggestions}
+    assert "resource:demo:foo:view-table" in names
+    # Each suggestion carries a human-readable display string
+    assert all(s["display"] for s in suggestions)
+
+
 async def _usage_rows(ds, token_id):
     db = ds.get_internal_database()
     return [

--- a/tests/test_managed_tokens.py
+++ b/tests/test_managed_tokens.py
@@ -723,6 +723,22 @@ async def test_edit_page_shows_recent_usage_suggestion(ds_managed):
 
 
 @pytest.mark.asyncio
+async def test_edit_page_lockdown_has_caveat(ds_managed):
+    token_id, token = await _create_token(ds_managed, "owner")
+    await ds_managed.client.get(
+        "/demo/foo.json", headers={"Authorization": "Bearer {}".format(token)}
+    )
+    cookies = {"ds_actor": ds_managed.client.actor_cookie({"id": "owner"})}
+    response = await ds_managed.client.get(
+        "/-/api/tokens/{}/edit".format(token_id), cookies=cookies
+    )
+    assert response.status_code == 200
+    # The lockdown panel warns that only directly-accessed resources are
+    # captured, not ones the token merely listed or browsed
+    assert "accessed directly" in response.text
+
+
+@pytest.mark.asyncio
 async def test_details_page_has_edit_link(ds_managed):
     token_id, _ = await _create_token(ds_managed, "owner")
     cookies = {"ds_actor": ds_managed.client.actor_cookie({"id": "owner"})}

--- a/tests/test_managed_tokens.py
+++ b/tests/test_managed_tokens.py
@@ -591,6 +591,73 @@ async def test_handler_create_token_stores_abbreviated_r(ds_managed):
     }
 
 
+async def _usage_rows(ds, token_id):
+    db = ds.get_internal_database()
+    return [
+        dict(r)
+        for r in (
+            await db.execute(
+                "select * from auth_tokens_usage where token_id = :t order by id",
+                {"t": token_id},
+            )
+        ).rows
+    ]
+
+
+@pytest.mark.asyncio
+async def test_token_usage_is_recorded(ds_managed):
+    """Using a token records the permission checks it triggered."""
+    token_id, token = await _create_token(ds_managed)
+    response = await ds_managed.client.get(
+        "/demo/foo.json", headers={"Authorization": "Bearer {}".format(token)}
+    )
+    assert response.status_code == 200
+    rows = await _usage_rows(ds_managed, token_id)
+    assert rows
+    # Only checks attributed to this token are recorded
+    assert all(r["token_id"] == token_id for r in rows)
+    seen = {(r["action"], r["parent"], r["child"], r["result"]) for r in rows}
+    assert ("view-table", "demo", "foo", 1) in seen
+
+
+@pytest.mark.asyncio
+async def test_token_usage_not_duplicated(ds_managed):
+    """A later request must not re-insert checks that are still in the
+    in-memory deque from an earlier request."""
+    token_id, token = await _create_token(ds_managed)
+    await ds_managed.client.get(
+        "/demo/foo.json", headers={"Authorization": "Bearer {}".format(token)}
+    )
+    first = await _usage_rows(ds_managed, token_id)
+    assert first
+    # An anonymous request produces no new token checks
+    await ds_managed.client.get("/demo/foo.json")
+    second = await _usage_rows(ds_managed, token_id)
+    assert len(second) == len(first)
+
+
+@pytest.mark.asyncio
+async def test_token_usage_can_be_disabled(db_path):
+    ds = Datasette(
+        [db_path],
+        plugin_config={
+            "datasette-auth-tokens": {
+                "manage_tokens": True,
+                "param": "_auth_token",
+                "log_token_usage": False,
+            }
+        },
+        config={"permissions": {"auth-tokens-create": {"id": "*"}}},
+    )
+    token_id, token = await _create_token(ds)
+    await ds.client.get(
+        "/demo/foo.json", headers={"Authorization": "Bearer {}".format(token)}
+    )
+    db = ds.get_internal_database()
+    count = (await db.execute("select count(*) from auth_tokens_usage")).first()[0]
+    assert count == 0
+
+
 @pytest.mark.asyncio
 async def test_handler_create_token_when_signed_tokens_disabled(db_path):
     """Creating a managed token with restrictions must work even when the

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,4 +1,5 @@
 from datasette_auth_tokens.migrations import migration
+from datasette_auth_tokens.utils import prune_token_usage
 import sqlite_utils
 
 OLD_CREATE_TABLES_SQL = """
@@ -77,3 +78,57 @@ def test_usage_table_created():
     index_names = {index.name for index in db["auth_tokens_usage"].indexes}
     assert "idx_auth_tokens_usage_dedup" in index_names
     assert "idx_auth_tokens_usage_token_time" in index_names
+
+
+def _insert_usage(db, token_id, count, base_ms, step=1):
+    db["auth_tokens_usage"].insert_all(
+        [
+            {
+                "token_id": token_id,
+                "when_iso": str(base_ms + i * step),
+                "created_ms": base_ms + i * step,
+                "action": "view-table",
+                "parent": "demo",
+                "child": "foo",
+                "result": 1,
+            }
+            for i in range(count)
+        ]
+    )
+
+
+def test_prune_caps_at_1000_recent():
+    db = sqlite_utils.Database(memory=True)
+    migration.apply(db)
+    now_ms = 10**12
+    # 1500 rows all within the 5 minute window
+    _insert_usage(db, token_id=1, count=1500, base_ms=now_ms)
+    prune_token_usage(db.conn, 1, now_ms + 2000)
+    rows = list(db["auth_tokens_usage"].rows)
+    assert len(rows) == 1000
+    # The newest 1000 (largest ids) should be kept
+    assert min(r["id"] for r in rows) == 501
+
+
+def test_prune_keeps_newest_200_when_old():
+    db = sqlite_utils.Database(memory=True)
+    migration.apply(db)
+    now_ms = 10**12
+    old = now_ms - 10**9  # well over 5 minutes old
+    _insert_usage(db, token_id=1, count=350, base_ms=old)
+    prune_token_usage(db.conn, 1, now_ms)
+    rows = list(db["auth_tokens_usage"].rows)
+    assert len(rows) == 200
+    assert min(r["id"] for r in rows) == 151
+
+
+def test_prune_only_touches_given_token():
+    db = sqlite_utils.Database(memory=True)
+    migration.apply(db)
+    now_ms = 10**12
+    old = now_ms - 10**9
+    _insert_usage(db, token_id=1, count=350, base_ms=old)
+    _insert_usage(db, token_id=2, count=10, base_ms=old)
+    prune_token_usage(db.conn, 1, now_ms)
+    assert db["auth_tokens_usage"].count_where("token_id = 1") == 200
+    assert db["auth_tokens_usage"].count_where("token_id = 2") == 10

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -58,3 +58,22 @@ def test_migrate_from_original():
         "ended_timestamp",
         "secret_version",
     ]
+
+
+def test_usage_table_created():
+    db = sqlite_utils.Database(memory=True)
+    migration.apply(db)
+    assert "auth_tokens_usage" in db.table_names()
+    assert db["auth_tokens_usage"].columns_dict == {
+        "id": int,
+        "token_id": int,
+        "when_iso": str,
+        "created_ms": int,
+        "action": str,
+        "parent": str,
+        "child": str,
+        "result": int,
+    }
+    index_names = {index.name for index in db["auth_tokens_usage"].indexes}
+    assert "idx_auth_tokens_usage_dedup" in index_names
+    assert "idx_auth_tokens_usage_token_time" in index_names


### PR DESCRIPTION
Captures the design for two features:

- Editing the permissions of an existing database-backed token via a new
  /-/api/tokens/{id}/edit page, gated on a new auth-tokens-edit-all action.
- A "lock it down to recently-used actions" workflow backed by a new
  auth_tokens_usage table, populated by an asgi_wrapper that drains
  token-attributed permission checks from datasette._permission_checks at
  the end of each request, with per-token retention rules.

This is the reference document for the work that follows.